### PR TITLE
fix: update ignores.yaml

### DIFF
--- a/versions/datastax/3.22.0/ignore.yaml
+++ b/versions/datastax/3.22.0/ignore.yaml
@@ -31,6 +31,7 @@ tests:
 
     # COMPACT STORAGE is deprecated in Scylla (https://github.com/scylladb/scylladb/issues/12263)
     - SimpleStatement_With_No_Compact_Enabled_Should_Reveal_Non_Schema_Columns
+    - SimpleStatement_With_No_Compact_Disabled_Should_Not_Reveal_Non_Schema_Columns
 
     # dclocal_read_repair_chance and read_repair_chance are removed in Scylla 6.1 (https://github.com/scylladb/scylladb/pull/18087)
     - ColumnClusteringOrderReversedTest
@@ -59,4 +60,32 @@ tests:
 
     # Cassandra only; Scylla does not support transient replication
     - TokenAware_TransientReplication_NoHopsAndOnlyFullReplicas
+
+    # UDF: lua doesn't support syntax used in the test
+    - GetFunction_Should_Return_Most_Up_To_Date_Metadata_Via_Events
+
+    # The tests are already marked as skipped in the driver code. But this doesn't prevent the test suite setup from running.
+    # Marking the tests as ignored here to save time on their setup/teardown execution.
+    - LargeDataTests
+    - MetadataTests
+    - MultiThreadingTests
+    - PoolTests
+    - PrepareLongTests
+    - SpeculativeExecutionLongTests
+    - StressTests
+    - TransitionalAuthenticationTests
+    - ProxyAuthenticationTests
+    - SessionDseAuthenticationTests
+    - CloudIntegrationTests
+    - CoreGraphTests
+    - GraphTests
+    - InsightsIntegrationTests
+    - DateRangeTests
+    - FoundBugTests
+    - GeometryTests
+    - LoadBalancingPolicyTests
+    - ConsistencyTests
+    - LoadBalancingPolicyTests
+    - ReconnectionPolicyTests
+    - RetryPolicyTests
   flaky:


### PR DESCRIPTION
Add to ignore list the test classes, which tests are not executed at all (as the whole test class is marked to be skipped in the driver code). This allows skipping execution of these test classes' setup/teardown fixtures and potentially would save some when executing tests in CI.

Reduced the tests execution time by ~25 mins, e.g. [csharp-driver-matrix-tes](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/csharp-driver-matrix-test/17/) (previously the pipeline step of tests execution was ~3h10m)