### PR TITLE
Stabilize tests in CI

### DIFF
--- a/run.py
+++ b/run.py
@@ -170,6 +170,7 @@ class Run:
                 ignore_filter = f"({ignore_tests})" if ignore_tests else ""
 
                 test_cmd = (
+                    'SCYLLA_EXT_OPTS="--smp 2 --memory 2G" '
                     f'SIMULACRON_PATH={simulacron_path} '
                     f'dotnet test {test_config.test_project} {test_config.test_command_args} {junit_logger} '
                     f'--filter "{ignore_filter}"')

--- a/versions/datastax/3.22.0/patch
+++ b/versions/datastax/3.22.0/patch
@@ -1,5 +1,18 @@
+diff --git a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+index e972fb34..c46b4017 100644
+--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+@@ -190,7 +190,7 @@ namespace Cassandra.IntegrationTests.Core
+         [Category(TestCategory.RealClusterLong)]
+         public async Task Should_Remove_Decommissioned_Node()
+         {
+-            const int numberOfNodes = 2;
++            const int numberOfNodes = 3;
+             _realCluster = TestClusterManager.CreateNew(numberOfNodes);
+             var cluster = ClusterBuilder().AddContactPoint(_realCluster.InitialContactPoint).Build();
+ 
 diff --git a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
-index b3d8c586..389d188d 100644
+index b3d8c586..c561c611 100644
 --- a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
 +++ b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
 @@ -50,7 +50,7 @@ namespace Cassandra.IntegrationTests.Core
@@ -11,6 +24,110 @@ index b3d8c586..389d188d 100644
                  {
                      setupQueries.Add($"CREATE TABLE {TableCompactStorage} (key blob PRIMARY KEY, bar int, baz uuid)" +
                                       $" WITH COMPACT STORAGE");
+diff --git a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+index 659ecf4d..9c22f983 100644
+--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+@@ -34,6 +34,35 @@ namespace Cassandra.IntegrationTests.Core
+     {
+         private readonly string _tableName = "tbl" + Guid.NewGuid().ToString("N").ToLower();
+         private const string AllTypesTableName = "all_types_table_prepared";
++        private readonly List<ICluster> _privateClusterInstances = new List<ICluster>();
++
++        protected override ICluster GetNewTemporaryCluster(Action<Builder> build = null)
++        {
++            var builder = ClusterBuilder()
++                          .AddContactPoint(TestCluster.InitialContactPoint)
++                          .WithSocketOptions(new SocketOptions().SetConnectTimeoutMillis(30000).SetReadTimeoutMillis(22000));
++            build?.Invoke(builder);
++            var cluster = builder.Build();
++            _privateClusterInstances.Add(cluster);
++            return cluster;
++        }
++
++        public override void TearDown()
++        {
++            foreach (var c in _privateClusterInstances)
++            {
++                try
++                {
++                    c.Dispose();
++                }
++                catch
++                {
++                    // ignored
++                }
++            }
++            _privateClusterInstances.Clear();
++            base.TearDown();
++        }
+
+         public PreparedStatementsTests() : base(3)
+         {
+@@ -163,8 +192,8 @@ namespace Cassandra.IntegrationTests.Core
+         {
+             byte[] originalResultMetadataId = null;
+             // Use 2 different clusters as the prepared statement cache should be different
+-            using (var cluster1 = ClusterBuilder().AddContactPoint(TestClusterManager.InitialContactPoint).Build())
+-            using (var cluster2 = ClusterBuilder().AddContactPoint(TestClusterManager.InitialContactPoint).Build())
++            using (var cluster1 = GetNewTemporaryCluster())
++            using (var cluster2 = GetNewTemporaryCluster())
+             {
+                 var session1 = cluster1.Connect();
+                 var session2 = cluster2.Connect();
+@@ -906,13 +935,12 @@ namespace Cassandra.IntegrationTests.Core
+
+         private void TestKeyspaceInPrepareNotSupported(bool specifyProtocol)
+         {
+-            var builder = ClusterBuilder().AddContactPoint(TestClusterManager.InitialContactPoint);
+-            if (specifyProtocol)
+-            {
+-                builder.WithMaxProtocolVersion(ProtocolVersion.V4);
+-            }
+-
+-            using (var cluster = builder.Build())
++            using (var cluster = GetNewTemporaryCluster(builder => {
++                       if (specifyProtocol)
++                       {
++                           builder.WithMaxProtocolVersion(ProtocolVersion.V4);
++                       }
++                   }))
+             {
+                 var session = cluster.Connect(KeyspaceName);
+
+@@ -1114,7 +1142,7 @@ namespace Cassandra.IntegrationTests.Core
+         [TestCassandraVersion(4, 0, Comparison.LessThan)]
+         public void BatchStatement_With_Keyspace_Defined_On_Lower_Protocol_Versions()
+         {
+-            using (var cluster = ClusterBuilder().AddContactPoint(TestClusterManager.InitialContactPoint).Build())
++            using (var cluster = GetNewTemporaryCluster())
+             {
+                 var session = cluster.Connect("system");
+                 var query = new SimpleStatement(
+@@ -1151,9 +1179,7 @@ namespace Cassandra.IntegrationTests.Core
+
+             var tableName = TestUtils.GetUniqueTableName();
+             using (var cluster = 
+-                ClusterBuilder()
+-                       .AddContactPoint(TestClusterManager.InitialContactPoint)
+-                       .WithQueryTimeout(500000).Build())
++                   GetNewTemporaryCluster(builder => builder.WithQueryTimeout(500000)))
+             {
+                 var session = cluster.Connect();
+                 session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (a int PRIMARY KEY, b int, c int)");
+diff --git a/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs b/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
+index 6e4e736f..ec89a113 100644
+--- a/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/SchemaAgreementTests.cs
+@@ -29,7 +29,7 @@ namespace Cassandra.IntegrationTests.Core
+     {
+         private volatile bool _paused = false;
+ 
+-        public SchemaAgreementTests() : base(2, false)
++        public SchemaAgreementTests() : base(3, false)
+         {
+         }
+
 diff --git a/src/Cassandra.IntegrationTests/Core/UdfTests.cs b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
 index c14cb094..86470c7d 100644
 --- a/src/Cassandra.IntegrationTests/Core/UdfTests.cs


### PR DESCRIPTION
A few tests were failing when running on a local engineer machine, but failing in CI.
Explicitly setting CPU/RAM resources limits for scylla helped to have them passing - now scylla-ccm resources
limits for CPU and RAM are set through SCYLLA_EXT_OPTS env. var to smp=2 and memory=2G values
(which 1G per core, as the memory is divided between cores).

Few more tests were having issues due to their setup/teardown was inappropriately executed:
- PreparedStatementsTests and ClusterTests test suites are updated to create a 3-node test cluster,
instead of 2-nodes one, for raft algorithm to function correctly
- PreparedStatementsTests test suite is updated to use overidden  implementation of GetNewTemporaryCluster
and TearDown, instead of the implementations of the base SharedClusterTest class. This change isolates
PreparedStatementsTests from interference by other test classes that inherit from SharedClusterTest and run
concurrently, causing race condition issues.