### PR TITLE
Use --init flag in docker run command when running tests

### DIFF
--- a/report_templates/report.html
+++ b/report_templates/report.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{{ subject }}</title>
+    <style>
+        .blue   { color: blue; }
+        .fbold  { font-weight: bold; }
+        .red    { color: red; }
+        .green  { color: green; }
+        .tan    { color: tan; }
+        .lightgreen { color: #90EE90; }
+        .orange { color: orange; }
+        .black  { color: black; }
+        .fnormal { font-weight: normal; }
+        .notice { font-size:120%; }
+        .small { font-size:80%; }
+        #results_table {
+            font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+            border-collapse: collapse;
+            width: 50%;
+        }
+        #results_table td, #results_table th {
+            border: 1px solid #ddd;
+            padding: 8px;
+
+        }
+        #results_table tr:nth-child(even){background-color: #f2f2f2;}
+        #results_table tr:hover {background-color: #ddd;}
+        #results_table th {
+            padding-top: 12px;
+            padding-bottom: 12px;
+            text-align: left;
+            background-color: #85C1E9;
+            color: white;
+        }
+
+        .result_table {
+            font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+            border-collapse: collapse;
+            vertical-align: top;
+            width: 50%;
+        }
+
+        .result_table tr:nth-child(even) {
+            background-color: #f2f2f2;
+        }
+
+        .longevity_run_failure_table tr:nth-child(even) {
+            background-color: #f2f2f2;
+        }
+
+        .longevity_result_runs {
+            vertical-align: top;
+        }
+
+        .result_table td, .result_table th {
+            border: 1px solid #ddd;
+            text-align: center;
+        }
+
+        .result_table th {
+            padding: 8px;
+            text-align: center;
+            background-color: #85C1E9;
+            color: white;
+        }
+
+        .result_table_error {
+            padding: 8px;
+            text-align: center;
+            background-color: red;
+            color: white;
+        }
+
+        .divRow
+        {
+           display: block;
+           width: 100%;
+           border: 0 none;
+           padding: 0;
+           margin: 0;
+           border-bottom: 1px solid #ddd;
+           word-wrap: break-word;
+           white-space: nowrap;
+        }
+        .divCellLeft
+        {
+            display: inline-block;
+            width: 35%;
+            border-top: 0 none;
+            border-left: 0 none;
+            border-right: 1px solid #ddd;
+            border-bottom: 0 none;
+            text-align: center;
+            margin: 0;
+            padding: 0;
+            word-wrap: break-word;
+            white-space: nowrap;
+        }
+        .divCellRight
+        {
+            display: inline-block;
+            width: 65%;
+            border: 0 none;
+            text-align: left;
+            margin: 0;
+            padding: 0;
+            white-space: nowrap;
+
+        }
+
+    </style>
+</head>
+<body>
+
+{% block test_info %}
+    <h3>Test details</h3>
+    <div>
+        <ul>
+            {% if scylla_version %}
+            <li><span class="fbold">Scylla Version:</span> {{ scylla_version }}</li>
+            {% endif %}
+            {% if build_id %}
+            <li><span class="fbold">Build Id:</span> {{ build_id }}</li>
+            {% endif %}
+            {% if driver_remote %}
+            <li><span class="fbold">Driver repository:</span> {{ driver_remote }}</li>
+            {% endif %}
+            {% if start_time %}
+            <li><span class="fbold">Start time:</span> {{ start_time }}</li>
+            {% endif %}
+            {% if end_time %}
+            <li><span class="fbold">End time:</span> {{ end_time }}</li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}
+
+{% block test_results %}
+    <h3>
+        <span>Test result</span>
+    </h3>
+    {% for version, res in results.items() %}
+        <h4 class='fbold notice'>Driver version: {{ version }}</h4>
+        {% for test, summary in res.items() %}
+            {% if summary.testsuite_summary %}
+
+                <table class='result_table'>
+                    <tr>
+                        <th>Test</th>
+                        <th>Duration</th>
+                        <th>Total</th>
+                        <th>Passed</th>
+                        <th>Failures</th>
+                        <th>Errors</th>
+                        <th>Skipped</th>
+                        <th>Ignored On Failure</th>
+                    </tr>
+                    <tr>
+                        <td>{{ test }}</td>
+                        <td>{{ summary.testsuite_summary.time }}</td>
+                        <td>{{ summary.testsuite_summary.tests }}</td>
+                        <td>{{ summary.testsuite_summary.tests - summary.testsuite_summary.skipped - summary.testsuite_summary.failures - summary.testsuite_summary.errors }}</td>
+                        {% if summary.testsuite_summary.failures == 0 %}
+                            <td>{{ summary.testsuite_summary.failures }}</td>
+                        {% else %}
+                            <td class='result_table_error'>{{ summary.testsuite_summary.failures }}</td>
+                        {% endif %}
+                        {% if summary.testsuite_summary.errors == 0 %}
+                            <td>{{ summary.testsuite_summary.errors }}</td>
+                        {% else %}
+                            <td class='result_table_error'>{{ summary.testsuite_summary.errors }}</td>
+                        {% endif %}
+                        <td>{{ summary.testsuite_summary.skipped }}</td>
+                        <td>{{ summary.testsuite_summary.ignored_on_failure }}</td>
+                    </tr>
+                </table>
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+{% endblock %}
+
+{% block body %}
+{% endblock %}
+
+{% block links %}
+    <h3>Links:</h3>
+    <ul>
+        {% if build_url %}
+            <li><a href={{ build_url }}>Build URL</a></li>
+        {% endif %}
+    </ul>
+{% endblock %}
+</body>
+</html>

--- a/run.py
+++ b/run.py
@@ -170,7 +170,6 @@ class Run:
                 ignore_filter = f"({ignore_tests})" if ignore_tests else ""
 
                 test_cmd = (
-                    'SCYLLA_EXT_OPTS="--smp 2 --memory 2G" '
                     f'SIMULACRON_PATH={simulacron_path} '
                     f'dotnet test {test_config.test_project} {test_config.test_command_args} {junit_logger} '
                     f'--filter "{ignore_filter}"')

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -56,7 +56,7 @@ for gid in $(id -G); do
     group_args+=(--group-add "$gid")
 done
 
-docker_cmd="docker run --detach=true \
+docker_cmd="docker run --init --detach=true \
     ${WORKSPACE_MNT} \
     ${SCYLLA_OPTIONS} \
     ${DOCKER_CONFIG_MNT} \

--- a/versions/datastax/3.22.0/ignore.yaml
+++ b/versions/datastax/3.22.0/ignore.yaml
@@ -64,28 +64,4 @@ tests:
     # UDF: lua doesn't support syntax used in the test
     - GetFunction_Should_Return_Most_Up_To_Date_Metadata_Via_Events
 
-    # The tests are already marked as skipped in the driver code. But this doesn't prevent the test suite setup from running.
-    # Marking the tests as ignored here to save time on their setup/teardown execution.
-    - LargeDataTests
-    - MetadataTests
-    - MultiThreadingTests
-    - PoolTests
-    - PrepareLongTests
-    - SpeculativeExecutionLongTests
-    - StressTests
-    - TransitionalAuthenticationTests
-    - ProxyAuthenticationTests
-    - SessionDseAuthenticationTests
-    - CloudIntegrationTests
-    - CoreGraphTests
-    - GraphTests
-    - InsightsIntegrationTests
-    - DateRangeTests
-    - FoundBugTests
-    - GeometryTests
-    - LoadBalancingPolicyTests
-    - ConsistencyTests
-    - LoadBalancingPolicyTests
-    - ReconnectionPolicyTests
-    - RetryPolicyTests
   flaky:

--- a/versions/datastax/3.22.0/patch
+++ b/versions/datastax/3.22.0/patch
@@ -1,5 +1,5 @@
 diff --git a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
-index e972fb34..c46b4017 100644
+index e972fb34..656a7a95 100644
 --- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
 +++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
 @@ -190,7 +190,7 @@ namespace Cassandra.IntegrationTests.Core
@@ -11,6 +11,19 @@ index e972fb34..c46b4017 100644
              _realCluster = TestClusterManager.CreateNew(numberOfNodes);
              var cluster = ClusterBuilder().AddContactPoint(_realCluster.InitialContactPoint).Build();
  
+@@ -210,10 +210,10 @@ namespace Cassandra.IntegrationTests.Core
+                 string decommisionedNode = null;
+                 TestHelper.RetryAssert(() =>
+                 {
+-                    decommisionedNode = _realCluster.ClusterIpPrefix + 2;
++                    decommisionedNode = _realCluster.ClusterIpPrefix + 3;
+                     Assert.False(TestUtils.IsNodeReachable(IPAddress.Parse(decommisionedNode)));
+                         //New node should be part of the metadata
+-                        Assert.AreEqual(1, cluster.AllHosts().Count);
++                        Assert.AreEqual(2, cluster.AllHosts().Count);
+                 }, 100, 100);
+                 var queried = false;
+                 for (var i = 0; i < 10; i++)
 diff --git a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
 index b3d8c586..c561c611 100644
 --- a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs


### PR DESCRIPTION
Some ccm operations (e.g. node stop) are implemented as system sygnals. But when tests are executed in a docker container in detached/non-interactive mode (basically, the main flow of driver matrix execution), such signals are not propagated properly to child processes, causing a few tests to fail.

This change helps to resolve signal handling problems by adding `--init` flag to `docker run` command.
Note: with this change we no longer need to explicitly ignore the test classes, which are annoted with skip
flag in the driver code - setup/teardown execution of these tests takes negligible amount of time after the fix.

Additionally, the change addresses 2 more issues:
 - Should_AllMetricsHaveValidValues_When_NodeIsDown test is patched to use 3 nodes in the test cluster, to ensure proper funtioning of raft algorithm
 - email report template is fixed to be able to render/send the CI build report to recepients

Testing:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dimakr/job/csharp-driver-matrix-test/24/
```
16:57:50  Test Run Successful.
16:57:50  Total tests: 856
16:57:50       Passed: 791
16:57:50      Skipped: 65
16:57:50   Total time: 14.1000 Minutes
```