### PR TITLE
Add patches for 3.22.0 datastax and 3.22.0.2 scylladb driver

### DIFF
--- a/versions/datastax/3.22.0/patch
+++ b/versions/datastax/3.22.0/patch
@@ -1,3 +1,97 @@
+diff --git a/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj b/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj
+index 4235055d..458f7bd0 100644
+--- a/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj
++++ b/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj
+@@ -7,9 +7,9 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
++    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
++    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
++    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+   </ItemGroup>
+diff --git a/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj b/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj
+index b70ffd5c..ca67b808 100644
+--- a/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj
++++ b/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj
+@@ -8,8 +8,8 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
++    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
++    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+   </ItemGroup>
+ 
+ </Project>
+diff --git a/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj b/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj
+index 07c63c1c..48dfbf23 100644
+--- a/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj
++++ b/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj
+@@ -8,7 +8,7 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.0" />
++    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+   </ItemGroup>
+ 
+   <ItemGroup>
+diff --git a/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs b/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
+index f38cfcc4..666754ff 100644
+--- a/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
++++ b/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
+@@ -52,12 +52,13 @@ namespace Cassandra.IntegrationTests.Data
+             var cmd = _connection.CreateCommand();
+ 
+             string keyspaceName = "keyspace_ado_1";
+-            cmd.CommandText = string.Format(TestUtils.CreateKeyspaceSimpleFormat, keyspaceName, 3);
++            cmd.CommandText = string.Format(TestUtils.CreateKeyspaceGenericFormat, keyspaceName, "NetworkTopologyStrategy",
++                                              string.Format("'replication_factor' : {0}", 3));
+             cmd.ExecuteNonQuery();
+ 
+             VerifyStatement(
+                 QueryType.Query,
+-                $"CREATE KEYSPACE \"{keyspaceName}\" WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : {3} }}",
++                $"CREATE KEYSPACE {keyspaceName} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {3} }}",
+                 1);
+ 
+             _connection.ChangeDatabase(keyspaceName);
+diff --git a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+index a867801f..9be22066 100644
+--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
++++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+@@ -92,7 +92,7 @@
+ 
+   <ItemGroup>
+     <PackageReference Include="App.Metrics" Version="3.2.0" />
+-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.5.1" />
++    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
+     <PackageReference Include="SSH.NET" Version="2020.0.2" />
+     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+@@ -105,7 +105,7 @@
+     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.0.2" />
+     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
+-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
++    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
+   </ItemGroup>
+   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net481' ">
+@@ -126,4 +126,4 @@
+   <ItemGroup>
+     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
 diff --git a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
 index e972fb34..656a7a95 100644
 --- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -24,6 +118,178 @@ index e972fb34..656a7a95 100644
                  }, 100, 100);
                  var queried = false;
                  for (var i = 0; i < 10; i++)
+diff --git a/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs b/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
+index eb243fd5..56ee38a0 100644
+--- a/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
+@@ -321,7 +321,7 @@ namespace Cassandra.IntegrationTests.Core
+ 
+         private void SetupForFrozenNestedCollectionTest(ISession session, string keyspaceName, string fqTableName)
+         {
+-            session.Execute(string.Format("CREATE KEYSPACE IF NOT EXISTS {0} WITH replication = {1};", keyspaceName, "{'class': 'SimpleStrategy', 'replication_factor' : 1}"));
++            session.Execute(string.Format("CREATE KEYSPACE IF NOT EXISTS {0} WITH replication = {1};", keyspaceName, "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}"));
+             session.Execute(string.Format("CREATE TABLE IF NOT EXISTS {0} " +
+                                           "(id int primary key, " +
+                                           "map1 map<text, frozen<list<text>>>," +
+diff --git a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+index 0f10f213..abb2dce3 100644
+--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+@@ -291,7 +291,7 @@ namespace Cassandra.IntegrationTests.Core
+             using (var connection = CreateConnection())
+             {
+                 await connection.Open().ConfigureAwait(false);
+-                await Query(connection, "CREATE KEYSPACE ks_conn_consume WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}")
++                await Query(connection, "CREATE KEYSPACE ks_conn_consume WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}")
+                     .ConfigureAwait(false);
+ 
+                 await Query(connection, "CREATE TABLE ks_conn_consume.tbl1 (id uuid primary key)").ConfigureAwait(false);
+@@ -514,9 +514,9 @@ namespace Cassandra.IntegrationTests.Core
+         public async Task SetKeyspace_Parallel_Calls_Serially_Executes()
+         {
+             const string queryKs1 = "create keyspace if not exists ks_to_switch_p1 WITH replication = " +
+-                                    "{'class': 'SimpleStrategy', 'replication_factor' : 1}";
++                                    "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+             const string queryKs2 = "create keyspace if not exists ks_to_switch_p2 WITH replication = " +
+-                                    "{'class': 'SimpleStrategy', 'replication_factor' : 1}";
++                                    "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+             // ReSharper disable AccessToDisposedClosure, AccessToModifiedClosure
+             using (var connection = CreateConnection())
+             {
+@@ -563,8 +563,8 @@ namespace Cassandra.IntegrationTests.Core
+         [Test]
+         public void SetKeyspace_Serial_Calls_Serially_Executes()
+         {
+-            const string queryKs1 = "create keyspace ks_to_switch_s1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
+-            const string queryKs2 = "create keyspace ks_to_switch_s2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
++            const string queryKs1 = "create keyspace ks_to_switch_s1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
++            const string queryKs2 = "create keyspace ks_to_switch_s2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+             using (var connection = CreateConnection())
+             {
+                 connection.Open().Wait();
+@@ -604,7 +604,7 @@ namespace Cassandra.IntegrationTests.Core
+         public void SetKeyspace_When_Disposing_Faults_Task()
+         {
+             //Invoke multiple times, as it involves different threads and can be scheduled differently
+-            const string queryKs = "create keyspace ks_to_switch_when1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
++            const string queryKs = "create keyspace ks_to_switch_when1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+             using (var connection = CreateConnection())
+             {
+                 connection.Open().Wait();
+diff --git a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+index 31d5d87a..4f3b26e8 100644
+--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+@@ -50,10 +50,10 @@ namespace Cassandra.IntegrationTests.Core
+             Assert.AreEqual(1, cluster.GetReplicas("ks2", new byte[] {0, 0, 0, 1}).Count);
+ 
+             const string createKeyspaceQuery = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
+-            session.Execute(string.Format(createKeyspaceQuery, "ks1", "SimpleStrategy", "'replication_factor' : 1"));
+-            session.Execute(string.Format(createKeyspaceQuery, "ks2", "SimpleStrategy", "'replication_factor' : 3"));
++            session.Execute(string.Format(createKeyspaceQuery, "ks1", "NetworkTopologyStrategy", "'replication_factor' : 1"));
++            session.Execute(string.Format(createKeyspaceQuery, "ks2", "NetworkTopologyStrategy", "'replication_factor' : 3"));
+             session.Execute(string.Format(createKeyspaceQuery, "ks3", "NetworkTopologyStrategy", "'dc1' : 1"));
+-            session.Execute(string.Format(createKeyspaceQuery, "\"KS4\"", "SimpleStrategy", "'replication_factor' : 3"));
++            session.Execute(string.Format(createKeyspaceQuery, "\"KS4\"", "NetworkTopologyStrategy", "'replication_factor' : 3"));
+             //Let the magic happen
+             Thread.Sleep(5000);
+             Assert.Greater(cluster.Metadata.GetKeyspaces().Count, initialLength);
+@@ -260,17 +260,18 @@ namespace Cassandra.IntegrationTests.Core
+         }
+ 
+         [Test]
+-        public void CheckSimpleStrategyKeyspace()
++        public void CheckNetworkTopologyStrategyKeyspace_SingleDatacenter()
+         {
+             ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(DefaultNodeCount);
+             var session = testCluster.Session;
+             bool durableWrites = Randomm.Instance.NextBoolean();
+             string keyspaceName = TestUtils.GetUniqueKeyspaceName();
+ 
+-            string strategyClass = ReplicationStrategies.SimpleStrategy;
++            string strategyClass = ReplicationStrategies.NetworkTopologyStrategy;
+             int replicationFactor = Randomm.Instance.Next(1, 21);
+             session.CreateKeyspace(keyspaceName,
+-                ReplicationStrategies.CreateSimpleStrategyReplicationProperty(replicationFactor),
++                ReplicationStrategies.CreateNetworkTopologyStrategyReplicationProperty(
++                    new Dictionary<string, int> { { "replication_factor", replicationFactor } }),
+                 durableWrites);
+             session.ChangeKeyspace(keyspaceName);
+ 
+@@ -338,7 +339,7 @@ namespace Cassandra.IntegrationTests.Core
+             ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(DefaultNodeCount);
+             var session = testCluster.Session;
+ 
+-            const string strategyClass = "SimpleStrategy";
++            const string strategyClass = "NetworkTopologyStrategy";
+             const bool durableWrites = false;
+             const int replicationFactor = 1;
+             string cql = string.Format(@"
+@@ -502,11 +503,11 @@ namespace Cassandra.IntegrationTests.Core
+             var testCluster = TestClusterManager.GetNonShareableTestCluster(3, DefaultMaxClusterCreateRetries, true, false);
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
++                "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};",
+                 "CREATE TABLE ks1.tbl1 (id uuid PRIMARY KEY, value text)",
+                 "SELECT * FROM ks1.tbl1",
+                 "SELECT * FROM ks1.tbl1 where id = d54cb06d-d168-45a0-b1b2-9f5c75435d3d",
+-                "CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
++                "CREATE KEYSPACE ks2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};",
+                 "CREATE TABLE ks2.tbl2 (id uuid PRIMARY KEY, value text)",
+                 "SELECT * FROM ks2.tbl2",
+                 "SELECT * FROM ks2.tbl2",
+@@ -558,7 +559,7 @@ namespace Cassandra.IntegrationTests.Core
+         {
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE ks_view_meta WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
++                "CREATE KEYSPACE ks_view_meta WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
+                 "CREATE TABLE ks_view_meta.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
+                 "CREATE MATERIALIZED VIEW ks_view_meta.dailyhigh AS SELECT user FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC)"
+             };
+@@ -616,7 +617,7 @@ namespace Cassandra.IntegrationTests.Core
+         {
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE ks_view_meta2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
++                "CREATE KEYSPACE ks_view_meta2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
+                 @"CREATE TABLE ks_view_meta2.t1 (""theKey"" INT, ""the;Clustering"" INT, ""the Value"" INT, PRIMARY KEY (""theKey"", ""the;Clustering""))",
+                 @"CREATE MATERIALIZED VIEW ks_view_meta2.mv1 AS SELECT ""theKey"", ""the;Clustering"", ""the Value"" FROM t1 WHERE ""theKey"" IS NOT NULL AND ""the;Clustering"" IS NOT NULL AND ""the Value"" IS NOT NULL PRIMARY KEY (""theKey"", ""the;Clustering"")"
+             };
+diff --git a/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs b/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
+index e2afeaee..75534e92 100644
+--- a/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
+@@ -58,7 +58,7 @@ namespace Cassandra.IntegrationTests.Core
+             ISession localSession = localCluster.Connect();
+             string keyspaceName = "kp_pi1_" + Randomm.RandomAlphaNum(10);
+ 
+-            localSession.Execute(string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};", keyspaceName));
++            localSession.Execute(string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};", keyspaceName));
+ 
+             TestUtils.WaitForSchemaAgreement(localCluster);
+             localSession.ChangeKeyspace(keyspaceName);
+@@ -228,8 +228,8 @@ namespace Cassandra.IntegrationTests.Core
+             ISession localSession = localCluster.Connect();
+             string keyspaceName = "kp_mat_" + Randomm.RandomAlphaNum(8);
+             localSession.Execute(
+-                string.Format(@"CREATE KEYSPACE {0} 
+-                    WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};"
++                string.Format(@"CREATE KEYSPACE {0}
++                    WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};"
+                                 , keyspaceName));
+             localSession.ChangeKeyspace(keyspaceName);
+ 
+@@ -294,7 +294,7 @@ namespace Cassandra.IntegrationTests.Core
+             ISession localSession = localCluster.Connect();
+             string keyspaceName = "keyspace" + Guid.NewGuid().ToString("N").ToLower();
+             localSession.Execute(
+-                    string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};", keyspaceName));
++                    string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};", keyspaceName));
+             localSession.ChangeKeyspace(keyspaceName);
+ 
+             string tableName = "table" + Guid.NewGuid().ToString("N").ToLower();
 diff --git a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
 index b3d8c586..c561c611 100644
 --- a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
@@ -37,8 +303,30 @@ index b3d8c586..c561c611 100644
                  {
                      setupQueries.Add($"CREATE TABLE {TableCompactStorage} (key blob PRIMARY KEY, bar int, baz uuid)" +
                                       $" WITH COMPACT STORAGE");
+diff --git a/src/Cassandra.IntegrationTests/Core/PoolTests.cs b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+index fd50c0ff..f09794cb 100644
+--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+@@ -303,7 +303,7 @@ namespace Cassandra.IntegrationTests.Core
+             {
+                 var session = cluster.Connect();
+                 //Will wait for all the nodes to have the same schema
+-                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
++                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
+             }
+         }
+ 
+@@ -322,7 +322,7 @@ namespace Cassandra.IntegrationTests.Core
+             {
+                 var session = cluster.Connect();
+                 //Will wait for all the nodes to have the same schema
+-                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
++                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
+                 session.ChangeKeyspace("ks1");
+                 TestHelper.ParallelInvoke(() =>
+                 {
 diff --git a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
-index 659ecf4d..9c22f983 100644
+index 659ecf4d..26839ef1 100644
 --- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
 +++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
 @@ -34,6 +34,35 @@ namespace Cassandra.IntegrationTests.Core
@@ -74,10 +362,10 @@ index 659ecf4d..9c22f983 100644
 +            _privateClusterInstances.Clear();
 +            base.TearDown();
 +        }
-
+ 
          public PreparedStatementsTests() : base(3)
          {
-@@ -163,8 +192,8 @@ namespace Cassandra.IntegrationTests.Core
+@@ -163,15 +192,15 @@ namespace Cassandra.IntegrationTests.Core
          {
              byte[] originalResultMetadataId = null;
              // Use 2 different clusters as the prepared statement cache should be different
@@ -88,8 +376,25 @@ index 659ecf4d..9c22f983 100644
              {
                  var session1 = cluster1.Connect();
                  var session2 = cluster2.Connect();
+ 
+                 // Create schema and insert data
+                 session1.Execute(
+-                    "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
++                    "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}");
+                 session1.ChangeKeyspace("ks1");
+                 session2.ChangeKeyspace("ks1");
+                 session1.Execute("CREATE TABLE table1 (id int PRIMARY KEY, a text, c text)");
+@@ -699,7 +728,7 @@ namespace Cassandra.IntegrationTests.Core
+                 .Build())
+             {
+                 var session = localCluster.Connect("system");
+-                session.Execute("CREATE KEYSPACE bound_changeks_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
++                session.Execute("CREATE KEYSPACE bound_changeks_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
+                 TestUtils.WaitForSchemaAgreement(localCluster);
+                 var ps = session.Prepare("SELECT * FROM system.local");
+                 session.ChangeKeyspace("bound_changeks_test");
 @@ -906,13 +935,12 @@ namespace Cassandra.IntegrationTests.Core
-
+ 
          private void TestKeyspaceInPrepareNotSupported(bool specifyProtocol)
          {
 -            var builder = ClusterBuilder().AddContactPoint(TestClusterManager.InitialContactPoint);
@@ -107,7 +412,7 @@ index 659ecf4d..9c22f983 100644
 +                   }))
              {
                  var session = cluster.Connect(KeyspaceName);
-
+ 
 @@ -1114,7 +1142,7 @@ namespace Cassandra.IntegrationTests.Core
          [TestCassandraVersion(4, 0, Comparison.LessThan)]
          public void BatchStatement_With_Keyspace_Defined_On_Lower_Protocol_Versions()
@@ -118,7 +423,7 @@ index 659ecf4d..9c22f983 100644
                  var session = cluster.Connect("system");
                  var query = new SimpleStatement(
 @@ -1151,9 +1179,7 @@ namespace Cassandra.IntegrationTests.Core
-
+ 
              var tableName = TestUtils.GetUniqueTableName();
              using (var cluster = 
 -                ClusterBuilder()
@@ -140,9 +445,53 @@ index 6e4e736f..ec89a113 100644
 +        public SchemaAgreementTests() : base(3, false)
          {
          }
-
+ 
+diff --git a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+index 35b1f6e8..a7eb2f43 100644
+--- a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+@@ -457,7 +457,7 @@ namespace Cassandra.IntegrationTests.Core
+         {
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
++                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta3 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
+                 "CREATE TABLE IF NOT EXISTS ks_view_meta3.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
+                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta3.monthlyhigh AS SELECT user, game, year, month, score, day FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND day IS NOT NULL PRIMARY KEY ((game, year, month), score, user, day) WITH CLUSTERING ORDER BY (score DESC, user DESC, day DESC) AND compaction = { 'class' : 'SizeTieredCompactionStrategy' }"
+             };
+@@ -510,7 +510,7 @@ namespace Cassandra.IntegrationTests.Core
+         {
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta4 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
++                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta4 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
+                 "CREATE TABLE IF NOT EXISTS ks_view_meta4.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
+                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta4.dailyhigh AS SELECT user, game, year, month, day, score FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC, user DESC)",
+                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta4.alltimehigh AS SELECT * FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY (game, score, year, month, day, user) WITH CLUSTERING ORDER BY (score DESC, year DESC, month DESC, day DESC, user DESC)"
+diff --git a/src/Cassandra.IntegrationTests/Core/StressTests.cs b/src/Cassandra.IntegrationTests/Core/StressTests.cs
+index bcb79b6e..55a54607 100644
+--- a/src/Cassandra.IntegrationTests/Core/StressTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/StressTests.cs
+@@ -44,7 +44,7 @@ namespace Cassandra.IntegrationTests.Core
+                 var session = cluster.Connect();
+                 var uniqueKsName = "keyspace_" + Randomm.RandomAlphaNum(10);
+                 session.Execute(@"CREATE KEYSPACE " + uniqueKsName +
+-                                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};");
++                                " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};");
+                 session.ChangeKeyspace(uniqueKsName);
+ 
+                 var tableName = "table_" + Guid.NewGuid().ToString("N").ToLower();
+@@ -101,7 +101,7 @@ namespace Cassandra.IntegrationTests.Core
+                 var session = cluster.Connect();
+                 var uniqueKsName = "keyspace_" + Randomm.RandomAlphaNum(10);
+                 session.Execute(@"CREATE KEYSPACE " + uniqueKsName +
+-                    " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};");
++                    " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};");
+                 session.ChangeKeyspace(uniqueKsName);
+ 
+                 var tableName = "table_" + Guid.NewGuid().ToString("N").ToLower();
 diff --git a/src/Cassandra.IntegrationTests/Core/UdfTests.cs b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
-index c14cb094..86470c7d 100644
+index c14cb094..8edee417 100644
 --- a/src/Cassandra.IntegrationTests/Core/UdfTests.cs
 +++ b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
 @@ -51,22 +51,26 @@ namespace Cassandra.IntegrationTests.Core
@@ -168,10 +517,11 @@ index c14cb094..86470c7d 100644
                  var session = cluster.Connect();
                  var queries = new List<string>
                  {
-                     "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
+-                    "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
 -                    "CREATE FUNCTION  ks_udf.return_one() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return 1;'",
 -                    "CREATE FUNCTION  ks_udf.plus(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return s+v;'",
 -                    "CREATE FUNCTION  ks_udf.plus(s bigint, v bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return s+v;'",
++                    "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}",
 +                    $"CREATE FUNCTION  ks_udf.return_one() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE {udfLanguage} AS 'return 1;'",
 +                    $"CREATE FUNCTION  ks_udf.plus(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE {udfLanguage} AS 'return s+v;'",
 +                    $"CREATE FUNCTION  ks_udf.plus(s bigint, v bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE {udfLanguage} AS 'return s+v;'",
@@ -236,8 +586,288 @@ index c14cb094..86470c7d 100644
              if (metadataSync)
              {
                  TestHelper.RetryAssert(() =>
+diff --git a/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs b/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs
+index 7307f4f5..7f0ae15a 100644
+--- a/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs
++++ b/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs
+@@ -73,7 +73,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             "NullableTimeUuidType timeuuid, " +
+             "StringType text, " +
+             "TimeUuidType timeuuid";
+-        
++
+         private const string CreateCqlDefaultColumnsCaseSensitive =
+             "\"BooleanType\" boolean, " +
+             "\"DateTimeOffsetType\" timestamp, " +
+@@ -98,17 +98,17 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             $"CREATE TABLE \"{AllDataTypesEntity.TableName}\" (" +
+                 CreateTable.CreateCqlColumns + ", " +
+                 "PRIMARY KEY (\"string_type\", \"guid_type\"))";
+-        
++
+         private static readonly string CreateCqlFormatStr =
+             "CREATE TABLE {0} (" +
+             CreateTable.CreateCqlColumns + ", " +
+             "PRIMARY KEY (\"string_type\", \"guid_type\"))";
+ 
+         private readonly string _uniqueKsName = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+-        
++
+         /// <summary>
+         /// Create a table using the method CreateIfNotExists
+-        /// 
++        ///
+         /// @Jira CSHARP-42  https://datastax-oss.atlassian.net/browse/CSHARP-42
+         ///  - Jira detail: CreateIfNotExists causes InvalidOperationException
+         /// </summary>
+@@ -138,7 +138,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             table.Create();
+             VerifyStatement(QueryType.Query, CreateTable.CreateCql, 1);
+         }
+-        
++
+         [Test, TestCassandraVersion(4, 0, Comparison.LessThan)]
+         public void Should_CreateTable_WhenClusteringOrderAndCompactOptionsAreSet()
+         {
+@@ -150,9 +150,9 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             var table = new Table<Tweet>(Session, config);
+             table.Create();
+             VerifyStatement(
+-                QueryType.Query, 
++                QueryType.Query,
+                 "CREATE TABLE Tweet (AuthorId text, Body text, TweetId uuid, PRIMARY KEY (TweetId, AuthorId)) " +
+-                "WITH CLUSTERING ORDER BY (AuthorId DESC) AND COMPACT STORAGE", 
++                "WITH CLUSTERING ORDER BY (AuthorId DESC) AND COMPACT STORAGE",
+                 1);
+         }
+ 
+@@ -163,7 +163,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             table.CreateAsync().GetAwaiter().GetResult();
+             VerifyStatement(QueryType.Query, CreateTable.CreateCql, 1);
+         }
+-        
++
+         [Test, TestCassandraVersion(4, 0, Comparison.LessThan)]
+         public void Should_CreateTableAsync_WhenClusteringOrderAndCompactOptionsAreSet()
+         {
+@@ -175,14 +175,14 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             var table = new Table<Tweet>(Session, config);
+             table.CreateAsync().GetAwaiter().GetResult();
+             VerifyStatement(
+-                QueryType.Query, 
++                QueryType.Query,
+                 "CREATE TABLE Tweet (AuthorId text, Body text, TweetId uuid, PRIMARY KEY (TweetId, AuthorId)) " +
+-                "WITH CLUSTERING ORDER BY (AuthorId DESC) AND COMPACT STORAGE", 
++                "WITH CLUSTERING ORDER BY (AuthorId DESC) AND COMPACT STORAGE",
+                 1);
+         }
+ 
+         /// <summary>
+-        /// Successfully create a table using the method Create, 
++        /// Successfully create a table using the method Create,
+         /// overriding the default table name given via the class' "name" meta-tag
+         /// </summary>
+         [Test, TestCassandraVersion(2, 0)]
+@@ -193,8 +193,8 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             Assert.AreEqual(uniqueTableName, table.Name);
+             table.Create();
+             VerifyStatement(
+-                QueryType.Query, 
+-                CreateTable.CreateCql.Replace($"\"{AllDataTypesEntity.TableName}\"", $"\"{uniqueTableName}\""), 
++                QueryType.Query,
++                CreateTable.CreateCql.Replace($"\"{AllDataTypesEntity.TableName}\"", $"\"{uniqueTableName}\""),
+                 1);
+         }
+ 
+@@ -206,8 +206,8 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             Assert.AreEqual(uniqueTableName, table.Name);
+             table.CreateAsync().GetAwaiter().GetResult();
+             VerifyStatement(
+-                QueryType.Query, 
+-                CreateTable.CreateCql.Replace($"\"{AllDataTypesEntity.TableName}\"", $"\"{uniqueTableName}\""), 
++                QueryType.Query,
++                CreateTable.CreateCql.Replace($"\"{AllDataTypesEntity.TableName}\"", $"\"{uniqueTableName}\""),
+                 1);
+         }
+ 
+@@ -224,8 +224,8 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+ 
+             table.Create();
+             VerifyStatement(
+-                QueryType.Query, 
+-                $"CREATE TABLE {tableName} ({CreateTable.CreateCqlDefaultColumns}, PRIMARY KEY (TimeUuidType))", 
++                QueryType.Query,
++                $"CREATE TABLE {tableName} ({CreateTable.CreateCqlDefaultColumns}, PRIMARY KEY (TimeUuidType))",
+                 1);
+ 
+             TestCluster.PrimeFluent(
+@@ -249,8 +249,8 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+ 
+             table.CreateAsync().GetAwaiter().GetResult();
+             VerifyStatement(
+-                QueryType.Query, 
+-                $"CREATE TABLE {tableName} ({CreateTable.CreateCqlDefaultColumns}, PRIMARY KEY (TimeUuidType))", 
++                QueryType.Query,
++                $"CREATE TABLE {tableName} ({CreateTable.CreateCqlDefaultColumns}, PRIMARY KEY (TimeUuidType))",
+                 1);
+ 
+             TestCluster.PrimeFluent(
+@@ -265,7 +265,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+         }
+ 
+         /// <summary>
+-        /// Attempt to create two tables of different types but with the same name using the Create method. 
++        /// Attempt to create two tables of different types but with the same name using the Create method.
+         /// Validate expected failure message
+         /// </summary>
+         [Test, TestCassandraVersion(2, 0)]
+@@ -309,7 +309,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             var mappingConfig = new MappingConfiguration().Define(new Map<AllDataTypesEntity>().TableName(staticTableName).CaseSensitive().PartitionKey(c => c.StringType));
+             var allDataTypesTable = new Table<AllDataTypesEntity>(Session, mappingConfig);
+             allDataTypesTable.Create();
+-            
++
+             VerifyStatement(
+                 QueryType.Query,
+                 $"CREATE TABLE \"{staticTableName}\" ({CreateTable.CreateCqlDefaultColumnsCaseSensitive}, PRIMARY KEY (\"StringType\"))",
+@@ -399,7 +399,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+         {
+             var uniqueTableName = TestUtils.GetUniqueTableName();
+             var uniqueKsName = TestUtils.GetUniqueKeyspaceName();
+-            
++
+             TestCluster.PrimeFluent(
+                 b => b.WhenQuery(string.Format(CreateTable.CreateCqlFormatStr, $"\"{uniqueKsName}\".\"{uniqueTableName}\""))
+                       .ThenServerError(ServerError.ConfigError, "msg"));
+@@ -413,7 +413,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+         {
+             var uniqueTableName = TestUtils.GetUniqueTableName();
+             var uniqueKsName = TestUtils.GetUniqueKeyspaceName();
+-            
++
+             TestCluster.PrimeFluent(
+                 b => b.WhenQuery(string.Format(CreateTable.CreateCqlFormatStr, $"\"{uniqueKsName}\".\"{uniqueTableName}\""))
+                       .ThenServerError(ServerError.ConfigError, "msg"));
+@@ -450,7 +450,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             VerifyStatement(
+                 QueryType.Query,
+                 $"CREATE KEYSPACE \"{newUniqueKsName}\" " +
+-                "WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : '1'}" +
++                "WITH replication = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : '1'}" +
+                 " AND durable_writes = true",
+                 1);
+ 
+@@ -531,14 +531,14 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+                 .ExplicitColumns());
+             var table = new Table<UdtAndTuplePoco>(Session, config);
+             table.Create();
+-            
++
+             VerifyStatement(
+                 QueryType.Query,
+                 "CREATE TABLE tbl_frozen_tuple (Id1 uuid, t frozen<tuple<bigint, bigint, text>>, PRIMARY KEY (Id1))",
+                 1);
+-            
++
+             PrimeSystemSchemaTables(
+-                _uniqueKsName, 
++                _uniqueKsName,
+                 "tbl_frozen_tuple",
+                 new []
+                 {
+@@ -571,7 +571,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+                                                                                   .AsCounter()));
+             var table = new Table<AllTypesEntity>(Session, config);
+             table.Create();
+-            
++
+             VerifyStatement(
+                 QueryType.Query,
+                 "CREATE TABLE tbl_with_counter_static (" +
+@@ -580,13 +580,13 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+                 1);
+ 
+             PrimeSystemSchemaTables(
+-                _uniqueKsName, 
++                _uniqueKsName,
+                 "tbl_with_counter_static",
+                 new []
+                 {
+                     new StubTableColumn("counter_col1", StubColumnKind.Regular, DataType.Counter),
+-                    new StubTableColumn("counter_col2", StubColumnKind.Regular, DataType.Counter), 
+-                    new StubTableColumn("id1", StubColumnKind.PartitionKey, DataType.Uuid), 
++                    new StubTableColumn("counter_col2", StubColumnKind.Regular, DataType.Counter),
++                    new StubTableColumn("id1", StubColumnKind.PartitionKey, DataType.Uuid),
+                     new StubTableColumn("id2", StubColumnKind.ClusteringKey, DataType.Text)
+                 });
+ 
+@@ -604,7 +604,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+         {
+             var table = new Table<TestEmptyClusteringColumnName>(Session, MappingConfiguration.Global);
+             table.CreateIfNotExists();
+-            
++
+             VerifyStatement(
+                 QueryType.Query,
+                 "CREATE TABLE \"test_empty_clustering_column_name\" (" +
+@@ -636,13 +636,13 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             VerifyStatement(
+                 QueryType.Query,
+                 string.Format(
+-                    AllDataTypesEntity.InsertCqlDefaultColumnsFormatStr, 
++                    AllDataTypesEntity.InsertCqlDefaultColumnsFormatStr,
+                     ksAndTable),
+                 1,
+                 expectedDataTypesEntityRow.GetColumnValuesForDefaultColumns());
+ 
+             // select record
+-            
++
+             TestCluster.PrimeFluent(
+                 b => b.WhenQuery(
+                           string.Format(AllDataTypesEntity.SelectCqlDefaultColumnsFormatStr, ksAndTable),
+@@ -652,7 +652,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+                           r => r.WithRow(expectedDataTypesEntityRow.GetColumnValuesForDefaultColumns())));
+ 
+ 
+-            var listOfAllDataTypesObjects = 
++            var listOfAllDataTypesObjects =
+                 (from x in table where x.StringType.Equals(uniqueKey) select x)
+                 .Execute().ToList();
+             Assert.NotNull(listOfAllDataTypesObjects);
+@@ -677,7 +677,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             VerifyBatchStatement(
+                 1,
+                 new [] { string.Format(
+-                    AllDataTypesEntity.InsertCqlDefaultColumnsFormatStr, 
++                    AllDataTypesEntity.InsertCqlDefaultColumnsFormatStr,
+                     ksAndTable) },
+                 new [] { expectedDataTypesEntityRow.GetColumnValuesForDefaultColumns() });
+ 
+@@ -689,9 +689,9 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+                           AllDataTypesEntity.GetDefaultColumns(),
+                           r => r.WithRow(expectedDataTypesEntityRow.GetColumnValuesForDefaultColumns())));
+ 
+-            var listOfAllDataTypesObjects = 
+-                (from x in table 
+-                 where x.StringType.Equals(uniqueKey) 
++            var listOfAllDataTypesObjects =
++                (from x in table
++                 where x.StringType.Equals(uniqueKey)
+                  select x)
+                 .Execute().ToList();
+             Assert.NotNull(listOfAllDataTypesObjects);
+@@ -734,7 +734,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             // ReSharper disable once InconsistentNaming
+             // ReSharper disable once UnusedMember.Local
+             public string cluster { get; set; }
+-            
++
+             [Column]
+             // ReSharper disable once InconsistentNaming
+             // ReSharper disable once UnusedMember.Local
 diff --git a/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs b/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
-index 7cecd275..c6927928 100644
+index 7cecd275..776a4f6f 100644
 --- a/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
 +++ b/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
 @@ -351,11 +351,13 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
@@ -254,10 +884,10 @@ index 7cecd275..c6927928 100644
              }
 +            var expectedErrMsg = TestClusterManager.IsScylla ? expectedMessageScylla : expectedMessageCassandra;
              StringAssert.Contains(expectedErrMsg, ex.Message);
-
+ 
              // Validate that select on lower case key does not fail
 @@ -379,11 +381,13 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
-
+ 
              // Validate expected exception
              var ex = Assert.Throws<InvalidQueryException>(() => cqlClient.Insert(pocoWithCustomAttributes));
 -            var expectedMessage = "Unknown identifier someotherstring";
@@ -271,13 +901,269 @@ index 7cecd275..c6927928 100644
 +            var expectedMessage = TestClusterManager.IsScylla ? expectedMessageScylla : expectedMessageCassandra;
              StringAssert.Contains(expectedMessage, ex.Message);
          }
-
+ 
+@@ -551,8 +555,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+                 var session = cluster.Connect();
+                 session.CreateKeyspace(anotherKeyspace, new Dictionary<string, string>
+                 {
+-                    { "class", "SimpleStrategy"},
+-                    { "replication_factor", "3"}
++                    { "class", "NetworkTopologyStrategy" },
++                    { "replication_factor", "1"}
+                 });
+                 session.ChangeKeyspace(anotherKeyspace);
+ 
+@@ -587,7 +591,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+                 var batch = mapper.CreateBatch();
+                 batch.Insert(user1);
+                 batch.Insert(user2);
+-                var consistency = ConsistencyLevel.All;
++                var consistency = ConsistencyLevel.Three;
+                 batch.WithOptions(o => o.SetConsistencyLevel(consistency));
+                 //Timestamp for BATCH request is supported in Cassandra 2.1 or above.
+                 if (TestClusterManager.CassandraVersion > Version.Parse("2.1"))
+@@ -596,8 +600,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+                     batch.WithOptions(o => o.SetTimestamp(timestamp));
+                 }
+                 var ex = Assert.Throws<UnavailableException>(() => mapper.Execute(batch));
+-                Assert.AreEqual(ConsistencyLevel.All, ex.Consistency,
+-                            "Consistency level of batch exception should be the same as specified at CqlQueryOptions: ALL");
++                Assert.AreEqual(ConsistencyLevel.Three, ex.Consistency,
++                            "Consistency level of batch exception should be the same as specified at CqlQueryOptions: THREE");
+                 Assert.AreEqual(3, ex.RequiredReplicas);
+                 Assert.AreEqual(1, ex.AliveReplicas);
+             }
+diff --git a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
+index 8b9121dc..3cded0f8 100644
+--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
++++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
+@@ -69,7 +69,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count);
+ 
+                 Assert.IsNull(newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName));
+-                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+ 
+                 newSession.Execute(createKeyspaceCql);
+                 TestUtils.WaitForSchemaAgreement(newCluster);
+@@ -85,7 +85,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public void TokenMap_Should_NotUpdateExistingTokenMap_When_KeyspaceIsRemoved()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+ 
+@@ -110,7 +110,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public void TokenMap_Should_NotUpdateExistingTokenMap_When_KeyspaceIsChanged()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+ 
+@@ -130,7 +130,8 @@ namespace Cassandra.IntegrationTests.MetadataTests
+ 
+                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
+                 var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
+-                var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}";
++                var dcName = newCluster.Metadata.Hosts.First().Datacenter;
++                var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', '{dcName}' : 2}}";
+                 newSession.Execute(alterKeyspaceCql);
+                 TestUtils.WaitForSchemaAgreement(newCluster);
+                 TestHelper.RetryAssert(() =>
+@@ -149,11 +150,11 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public async Task TokenMap_Should_RefreshTokenMapForSingleKeyspace_When_RefreshSchemaWithKeyspaceIsCalled()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+             keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+ 
+@@ -188,11 +189,11 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public async Task TokenMap_Should_RefreshTokenMapForAllKeyspaces_When_RefreshSchemaWithoutKeyspaceIsCalled()
+         {
+             var keyspaceName1 = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName1} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName1} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+ 
+diff --git a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
+index c390e258..2a36caaa 100644
+--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
++++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
+@@ -42,7 +42,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+             Assert.AreEqual(3, newCluster.Metadata.Hosts.Count);
+ 
+             Assert.IsNull(newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName));
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+ 
+             newSession.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(newCluster);
+@@ -64,7 +64,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public void TokenMap_Should_UpdateExistingTokenMap_When_KeyspaceIsRemoved()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             Session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(Cluster);
+ 
+@@ -85,7 +85,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public void TokenMap_Should_UpdateExistingTokenMap_When_KeyspaceIsChanged()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             Session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(Cluster);
+ 
+@@ -100,7 +100,8 @@ namespace Cassandra.IntegrationTests.MetadataTests
+ 
+             Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
+             var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
+-            var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}";
++            var dcName = newCluster.Metadata.Hosts.First().Datacenter;
++            var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', '{dcName}' : 2}}";
+             newSession.Execute(alterKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(newCluster);
+             TestHelper.RetryAssert(() =>
+diff --git a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
+index 92760652..6f377adb 100644
+--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
++++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
+@@ -60,7 +60,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+                 var sessionNotSync = ClusterObjNotSync.Connect();
+                 var sessionSync = ClusterObjSync.Connect();
+ 
+-                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+                 sessionNotSync.Execute(createKeyspaceCql);
+ 
+                 TestUtils.WaitForSchemaAgreement(ClusterObjNotSync);
+diff --git a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+index fe8e8da3..54e28b28 100644
+--- a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
++++ b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+@@ -55,8 +55,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+             }
+         }
+         /// <summary>
+-        /// Validate that no hops occur when inserting into a single partition 
+-        /// 
++        /// Validate that no hops occur when inserting into a single partition
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// </summary>
+@@ -89,8 +89,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+ 
+         /// <summary>
+-        /// Validate that no hops occur when inserting GUID values into the key 
+-        /// 
++        /// Validate that no hops occur when inserting GUID values into the key
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// </summary>
+@@ -126,8 +126,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+ 
+         /// <summary>
+-        /// Validate that no hops occur when inserting into a composite key 
+-        /// 
++        /// Validate that no hops occur when inserting into a composite key
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// </summary>
+@@ -200,8 +200,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+ 
+         /// <summary>
+-        /// Validate that no hops occur when inserting string values via a prepared statement 
+-        /// 
++        /// Validate that no hops occur when inserting string values via a prepared statement
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// @test_category prepared_statements
+@@ -240,8 +240,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+ 
+         /// <summary>
+-        /// Validate that no hops occur when inserting int values via a prepared statement 
+-        /// 
++        /// Validate that no hops occur when inserting int values via a prepared statement
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// @test_category prepared_statements
+@@ -277,8 +277,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+ 
+         /// <summary>
+-        /// Validate that hops occur when the wrong partition is targeted 
+-        /// 
++        /// Validate that hops occur when the wrong partition is targeted
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// </summary>
+@@ -323,7 +323,14 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+                 var session = cluster.Connect();
+                 Assert.AreEqual(256, cluster.AllHosts().First().Tokens.Count());
+                 var ks = TestUtils.GetUniqueKeyspaceName();
+-                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 1}}");
++                if (TestClusterManager.IsScylla)
++                {
++                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}} AND tablets = {{'enabled': false}}");
++                }
++                else
++                {
++                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}}");
++                }
+                 session.ChangeKeyspace(ks);
+                 session.Execute("CREATE TABLE tbl1 (id uuid primary key)");
+                 var ps = session.Prepare("INSERT INTO tbl1 (id) VALUES (?)");
+@@ -363,7 +370,14 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+                 // Connect without a keyspace
+                 var session = cluster.Connect();
+                 var ks = TestUtils.GetUniqueKeyspaceName();
+-                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}");
++                if (TestClusterManager.IsScylla)
++                {
++                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}} AND tablets = {{'enabled': false}}");
++                }
++                else
++                {
++                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}}");
++                }
+                 session.ChangeKeyspace(ks);
+                 session.Execute($"CREATE TABLE tbl1 (id uuid primary key)");
+                 var ps = session.Prepare($"INSERT INTO tbl1 (id) VALUES (?)");
 diff --git a/src/Cassandra.IntegrationTests/TestBase/TestDseVersion.cs b/src/Cassandra.IntegrationTests/TestBase/TestDseVersion.cs
 index b5303b43..7071921a 100644
 --- a/src/Cassandra.IntegrationTests/TestBase/TestDseVersion.cs
 +++ b/src/Cassandra.IntegrationTests/TestBase/TestDseVersion.cs
 @@ -106,6 +106,18 @@ namespace Cassandra.IntegrationTests.TestBase
-
+ 
          public static bool VersionMatch(Version expectedVersion, bool requiresDse, bool requiresOss, Comparison comparison, out string message)
          {
 +            if (TestClusterManager.IsScylla && requiresDse)
@@ -295,6 +1181,20 @@ index b5303b43..7071921a 100644
              if (TestClusterManager.IsDse && requiresOss)
              {
                  message = string.Format("Test designed to run with OSS {0} v{1} (executing DSE {2})", 
+diff --git a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+index c4ce8ac7..c8e8fd50 100644
+--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
++++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+@@ -39,7 +39,8 @@ namespace Cassandra.IntegrationTests.TestBase
+         private const int DefaultSleepIterationMs = 1000;
+ 
+         public static readonly string CreateKeyspaceSimpleFormat =
+-            "CREATE KEYSPACE \"{0}\" WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : {1} }}";
++            "CREATE KEYSPACE \"{0}\" WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {1} }}" +
++            (TestClusterManager.IsScylla ? " AND tablets = {{'enabled': false}}" : "");
+ 
+         public static readonly string CreateKeyspaceGenericFormat = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
+ 
 diff --git a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs b/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs
 index dde5d86f..780e968c 100644
 --- a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmBridge.cs
@@ -309,7 +1209,7 @@ index dde5d86f..780e968c 100644
 +        public string IpPrefix => $"127.0.{IdPrefix}.";
          public ICcmProcessExecuter CcmProcessExecuter { get; set; }
          private readonly string _dseInstallPath;
-
+ 
 -        public CcmBridge(string name, string ipPrefix, string dsePath, string version, ICcmProcessExecuter executor)
 +        public CcmBridge(string name, string idPrefix, string dsePath, string version, string scyllaVersion, ICcmProcessExecuter executor)
          {
@@ -322,12 +1222,12 @@ index dde5d86f..780e968c 100644
              Version = version;
 +            ScyllaVersion = scyllaVersion;
          }
-
+ 
          public void Dispose()
 @@ -64,18 +67,14 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
                  sslParams = "--ssl " + sslPath;
              }
-
+ 
 -            if (string.IsNullOrEmpty(_dseInstallPath))
 +            if (!string.IsNullOrEmpty(ScyllaVersion))
              {
@@ -358,9 +1258,9 @@ index dde5d86f..780e968c 100644
 +            {
 +               cmd += " --scylla";
 +            }
-
+ 
              var output = ExecuteCcm(string.Format(cmd, n, IpPrefix, n, 7000 + 100 * n, dc != null ? "-d " + dc : null));
-
+ 
 diff --git a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmCluster.cs b/src/Cassandra.IntegrationTests/TestClusterManagement/CcmCluster.cs
 index 087e60ef..3ee05464 100644
 --- a/src/Cassandra.IntegrationTests/TestClusterManagement/CcmCluster.cs
@@ -381,7 +1281,7 @@ index 087e60ef..3ee05464 100644
          private readonly ICcmProcessExecuter _executor;
          private CcmBridge _ccm;
          private int _nodeLength;
-
+ 
 -        public CcmCluster(string name, string clusterIpPrefix, string dsePath, ICcmProcessExecuter executor, string defaultKeyspace, string version)
 +        public CcmCluster(string name, string idPrefix, string dsePath, ICcmProcessExecuter executor, string defaultKeyspace, string version, string scyllaVersion = null)
          {
@@ -397,7 +1297,7 @@ index 087e60ef..3ee05464 100644
              Version = version;
 +            ScyllaVersion = scyllaVersion;
          }
-
+ 
          public void Create(int nodeLength, TestClusterOptions options = null)
          {
              _nodeLength = nodeLength;
@@ -420,13 +1320,13 @@ index 662a3cfd..3d1c8421 100644
 +        {
 +            return (_idPrefixCounter++).ToString();
 +        }
-
+ 
          private static readonly Version Version2Dot0 = new Version(2, 0);
          private static readonly Version Version2Dot1 = new Version(2, 1);
 @@ -114,6 +119,16 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
              get { return Environment.GetEnvironmentVariable("CASSANDRA_VERSION") ?? "3.11.2"; }
          }
-
+ 
 +        public static string ScyllaVersionString
 +        {
 +            get { return Environment.GetEnvironmentVariable("SCYLLA_VERSION"); }
@@ -455,3 +1355,58 @@ index 662a3cfd..3d1c8421 100644
              testCluster.Create(nodeLength, options);
              if (startCluster)
              {
+diff --git a/src/Cassandra/CqlQueryTools.cs b/src/Cassandra/CqlQueryTools.cs
+index d556e1a7..b13c5893 100644
+--- a/src/Cassandra/CqlQueryTools.cs
++++ b/src/Cassandra/CqlQueryTools.cs
+@@ -75,11 +75,11 @@ namespace Cassandra
+         {
+             if (replication == null)
+             {
+-                replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", "1" } };
++                replication = new Dictionary<string, string> { { "class", ReplicationStrategies.NetworkTopologyStrategy }, { "replication_factor", "1" } };
+             }
+ 
+             return string.Format(
+-                "CREATE KEYSPACE {3}{0} WITH replication = {1} AND durable_writes = {2}", 
++                "CREATE KEYSPACE {3}{0} WITH replication = {1} AND durable_writes = {2}",
+                 QuoteIdentifier(keyspace),
+                 Utils.ConvertToCqlMap(replication),
+                 durableWrites ? "true" : "false",
+diff --git a/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj b/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+index db4603ec..11857377 100644
+--- a/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
++++ b/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+@@ -23,8 +23,8 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
+-    <PackageReference Include="OpenTelemetry.Api" Version="1.7.0" />
++    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
++    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+   </ItemGroup>
+ 
+   <ItemGroup>
+diff --git a/src/Extensions/Cassandra.OpenTelemetry/OpenTelemetryRequestTracker.cs b/src/Extensions/Cassandra.OpenTelemetry/OpenTelemetryRequestTracker.cs
+index 08d3106c..66e348e4 100644
+--- a/src/Extensions/Cassandra.OpenTelemetry/OpenTelemetryRequestTracker.cs
++++ b/src/Extensions/Cassandra.OpenTelemetry/OpenTelemetryRequestTracker.cs
+@@ -134,7 +134,7 @@ namespace Cassandra.OpenTelemetry
+             }
+ 
+             activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+-            activity.RecordException(ex);
++            activity.AddException(ex);
+ 
+             activity.Dispose();
+ 
+@@ -183,7 +183,7 @@ namespace Cassandra.OpenTelemetry
+             }
+ 
+             activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+-            activity.RecordException(ex);
++            activity.AddException(ex);
+ 
+             activity.Dispose();
+ 

--- a/versions/scylla/3.22.0.2/patch
+++ b/versions/scylla/3.22.0.2/patch
@@ -1,5 +1,3842 @@
+diff --git a/Makefile b/Makefile
+index 9afaf0b1..20c18dac 100644
+--- a/Makefile
++++ b/Makefile
+@@ -13,7 +13,7 @@ SCYLLA_EXT_OPTS ?= --smp=2 --memory=4G
+ SIMULACRON_PATH ?= ${MAKEFILE_PATH}/ci/simulacron-standalone-0.12.0.jar
+
+ TARGET_FRAMEWORK ?=
+-
++SNK_FILE ?=
+ DEV_SNK_PUBLIC_KEY ?= 0024000004800000940000000602000000240000525341310004000001000100fb083dc01ba81b96b526327f232e7f4c1301c8ec177a2c66adecc315a9c2308f33ecd9dc70d6d1435107578b4dd04658c8f92a51a60d50c528ca6fba3955fa844fe79c884452024b0ba67d19a70140818aa61a1faeb23d5dcfe0bd9820d587829caf36d0ac7e0dc450d3654d5f5bee009dda3d11fd4066d4640b935c2ca048a4
+
+ ifeq (${CCM_CONFIG_DIR},)
+@@ -35,29 +35,33 @@ endif
+ export SCYLLA_EXT_OPTS
+ export SIMULACRON_PATH
+ export SCYLLA_VERSION
+-export SNK_FILE
+
++.PHONY: check
+ check:
+-	dotnet format --verify-no-changes --severity warn --verbosity diagnostic src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj & \
+-	dotnet format --verify-no-changes --severity warn --verbosity diagnostic src/Cassandra/Cassandra.csproj & \
+-	dotnet format --verify-no-changes --severity warn --verbosity diagnostic src/Cassandra.Tests/Cassandra.Tests.csproj & \
+-	wait
++	dotnet format --verify-no-changes --severity warn --verbosity diagnostic src/Cassandra/Cassandra.csproj
++	dotnet format --verify-no-changes --severity warn --verbosity diagnostic src/Cassandra.Tests/Cassandra.Tests.csproj
++	dotnet format --verify-no-changes --severity warn --verbosity diagnostic src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+
++.PHONY: fix
+ fix:
+-	dotnet format --severity warn --verbosity diagnostic src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj & \
+-	dotnet format --severity warn --verbosity diagnostic src/Cassandra/Cassandra.csproj & \
+-	dotnet format --severity warn --verbosity diagnostic src/Cassandra.Tests/Cassandra.Tests.csproj & \
+-	wait
++	dotnet format --severity warn --verbosity diagnostic src/Cassandra/Cassandra.csproj
++	dotnet format --severity warn --verbosity diagnostic src/Cassandra.Tests/Cassandra.Tests.csproj
++	dotnet format --severity warn --verbosity diagnostic src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+
++.PHONY: test-unit
+ test-unit: .use-development-snk
++	dotnet build-server shutdown
+ 	dotnet test $(TEST_TARGET_OPTIONS) src/Cassandra.Tests/Cassandra.Tests.csproj
+
+-TEST_INTEGRATION_SCYLLA_FILTER ?= (FullyQualifiedName!~ClientWarningsTests & FullyQualifiedName!~CustomPayloadTests & FullyQualifiedName!~Connect_With_Ssl_Test & FullyQualifiedName!~Should_UpdateHosts_When_HostIpChanges & FullyQualifiedName!~Should_UseNewHostInQueryPlans_When_HostIsDecommissionedAndJoinsAgain & FullyQualifiedName!~Should_RemoveNodeMetricsAndDisposeMetricsContext_When_HostIsRemoved & FullyQualifiedName!~Virtual_Keyspaces_Are_Included & FullyQualifiedName!~Virtual_Table_Metadata_Test & FullyQualifiedName!~SessionAuthenticationTests & FullyQualifiedName!~TypeSerializersTests & FullyQualifiedName!~Custom_MetadataTest & FullyQualifiedName!~LinqWhere_WithVectors & FullyQualifiedName!~SimpleStatement_With_No_Compact_Enabled_Should_Reveal_Non_Schema_Columns & FullyQualifiedName!~SimpleStatement_With_No_Compact_Disabled_Should_Not_Reveal_Non_Schema_Columns & FullyQualifiedName!~ColumnClusteringOrderReversedTest & FullyQualifiedName!~GetMaterializedView_Should_Refresh_View_Metadata_Via_Events & FullyQualifiedName!~MaterializedView_Base_Table_Column_Addition & FullyQualifiedName!~MultipleSecondaryIndexTest & FullyQualifiedName!~RaiseErrorOnInvalidMultipleSecondaryIndexTest & FullyQualifiedName!~TableMetadataAllTypesTest & FullyQualifiedName!~TableMetadataClusteringOrderTest & FullyQualifiedName!~TableMetadataCollectionsSecondaryIndexTest & FullyQualifiedName!~TableMetadataCompositePartitionKeyTest & FullyQualifiedName!~TupleMetadataTest & FullyQualifiedName!~Udt_Case_Sensitive_Metadata_Test & FullyQualifiedName!~UdtMetadataTest & FullyQualifiedName!~Should_Retrieve_Table_Metadata & FullyQualifiedName!~CreateTable_With_Frozen_Key & FullyQualifiedName!~CreateTable_With_Frozen_Udt & FullyQualifiedName!~CreateTable_With_Frozen_Value & FullyQualifiedName!~Should_AllMetricsHaveValidValues_When_AllNodesAreUp & FullyQualifiedName!~SimpleStatement_Dictionary_Parameters_CaseInsensitivity_ExcessOfParams & FullyQualifiedName!~SimpleStatement_Dictionary_Parameters_CaseInsensitivity_NoOverload & FullyQualifiedName!~TokenAware_TransientReplication_NoHopsAndOnlyFullReplicas & FullyQualifiedName!~GetFunction_Should_Return_Most_Up_To_Date_Metadata_Via_Events & FullyQualifiedName!~LargeDataTests & FullyQualifiedName!~MetadataTests & FullyQualifiedName!~MultiThreadingTests & FullyQualifiedName!~PoolTests & FullyQualifiedName!~PrepareLongTests & FullyQualifiedName!~SpeculativeExecutionLongTests & FullyQualifiedName!~StressTests & FullyQualifiedName!~TransitionalAuthenticationTests & FullyQualifiedName!~ProxyAuthenticationTests & FullyQualifiedName!~CloudIntegrationTests & FullyQualifiedName!~CoreGraphTests & FullyQualifiedName!~GraphTests & FullyQualifiedName!~InsightsIntegrationTests & FullyQualifiedName!~DateRangeTests & FullyQualifiedName!~FoundBugTests & FullyQualifiedName!~GeometryTests & FullyQualifiedName!~LoadBalancingPolicyTests & FullyQualifiedName!~ConsistencyTests & FullyQualifiedName!~LoadBalancingPolicyTests & FullyQualifiedName!~ReconnectionPolicyTests & FullyQualifiedName!~RetryPolicyTests)
++TEST_INTEGRATION_SCYLLA_FILTER ?= (FullyQualifiedName!~ClientWarningsTests & FullyQualifiedName!~CustomPayloadTests & FullyQualifiedName!~Connect_With_Ssl_Test & FullyQualifiedName!~Should_UpdateHosts_When_HostIpChanges & FullyQualifiedName!~Should_UseNewHostInQueryPlans_When_HostIsDecommissionedAndJoinsAgain & FullyQualifiedName!~Should_RemoveNodeMetricsAndDisposeMetricsContext_When_HostIsRemoved & FullyQualifiedName!~Virtual_Keyspaces_Are_Included & FullyQualifiedName!~Virtual_Table_Metadata_Test & FullyQualifiedName!~SessionAuthenticationTests & FullyQualifiedName!~Custom_MetadataTest & FullyQualifiedName!~Should_Use_Custom_TypeSerializers & FullyQualifiedName!~LinqWhere_WithVectors & FullyQualifiedName!~SimpleStatement_With_No_Compact_Enabled_Should_Reveal_Non_Schema_Columns & FullyQualifiedName!~SimpleStatement_With_No_Compact_Disabled_Should_Not_Reveal_Non_Schema_Columns & FullyQualifiedName!~ColumnClusteringOrderReversedTest & FullyQualifiedName!~GetMaterializedView_Should_Refresh_View_Metadata_Via_Events & FullyQualifiedName!~MaterializedView_Base_Table_Column_Addition & FullyQualifiedName!~MultipleSecondaryIndexTest & FullyQualifiedName!~RaiseErrorOnInvalidMultipleSecondaryIndexTest & FullyQualifiedName!~TableMetadataAllTypesTest & FullyQualifiedName!~TableMetadataClusteringOrderTest & FullyQualifiedName!~TableMetadataCollectionsSecondaryIndexTest & FullyQualifiedName!~TableMetadataCompositePartitionKeyTest & FullyQualifiedName!~TupleMetadataTest & FullyQualifiedName!~Udt_Case_Sensitive_Metadata_Test & FullyQualifiedName!~UdtMetadataTest & FullyQualifiedName!~Should_Retrieve_Table_Metadata & FullyQualifiedName!~CreateTable_With_Frozen_Key & FullyQualifiedName!~CreateTable_With_Frozen_Udt & FullyQualifiedName!~CreateTable_With_Frozen_Value & FullyQualifiedName!~Should_AllMetricsHaveValidValues_When_AllNodesAreUp & FullyQualifiedName!~SimpleStatement_Dictionary_Parameters_CaseInsensitivity_ExcessOfParams & FullyQualifiedName!~SimpleStatement_Dictionary_Parameters_CaseInsensitivity_NoOverload & FullyQualifiedName!~TokenAware_TransientReplication_NoHopsAndOnlyFullReplicas & FullyQualifiedName!~GetFunction_Should_Return_Most_Up_To_Date_Metadata_Via_Events & FullyQualifiedName!~LargeDataTests & FullyQualifiedName!~MetadataTests & FullyQualifiedName!~MultiThreadingTests & FullyQualifiedName!~PoolTests & FullyQualifiedName!~PrepareLongTests & FullyQualifiedName!~SpeculativeExecutionLongTests & FullyQualifiedName!~StressTests & FullyQualifiedName!~TransitionalAuthenticationTests & FullyQualifiedName!~ProxyAuthenticationTests & FullyQualifiedName!~CloudIntegrationTests & FullyQualifiedName!~CoreGraphTests & FullyQualifiedName!~GraphTests & FullyQualifiedName!~InsightsIntegrationTests & FullyQualifiedName!~DateRangeTests & FullyQualifiedName!~FoundBugTests & FullyQualifiedName!~GeometryTests & FullyQualifiedName!~LoadBalancingPolicyTests & FullyQualifiedName!~ConsistencyTests & FullyQualifiedName!~LoadBalancingPolicyTests & FullyQualifiedName!~ReconnectionPolicyTests & FullyQualifiedName!~RetryPolicyTests)
+ TEST_INTEGRATION_OPTIONS ?= -l "console;verbosity=detailed"
+ TEST_INTEGRATION_CSPROJ ?= src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
++.PHONY: test-integration-scylla
+ test-integration-scylla: .use-development-snk .prepare-scylla-ccm
++	dotnet build-server shutdown
+ 	CCM_DISTRIBUTION=scylla dotnet test $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --filter "$(TEST_INTEGRATION_SCYLLA_FILTER)"
+
++.PHONY: test-integration-cassandra
+ test-integration-cassandra: .use-development-snk .prepare-cassandra-ccm
+ 	CCM_DISTRIBUTION=cassandra dotnet test $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS)
+
+@@ -72,6 +76,7 @@ test-integration-cassandra: .use-development-snk .prepare-cassandra-ccm
+ 		echo ${CCM_CASSANDRA_VERSION} > ${CCM_CONFIG_DIR}/ccm-version; \
+   	fi
+
++.PHONY: install-cassandra-ccm
+ install-cassandra-ccm:
+ 	@echo "Install CCM ${CCM_CASSANDRA_VERSION}"
+ 	@pip install "git+https://${CCM_CASSANDRA_REPO}.git@${CCM_CASSANDRA_VERSION}"
+@@ -90,6 +95,7 @@ install-cassandra-ccm:
+ 		echo ${CCM_SCYLLA_VERSION} > ${CCM_CONFIG_DIR}/ccm-version; \
+   	fi
+
++.PHONY: install-scylla-ccm
+ install-scylla-ccm:
+ 	@echo "Installing Scylla CCM ${CCM_SCYLLA_VERSION}"
+ 	@pip install "git+https://${CCM_SCYLLA_REPO}.git@${CCM_SCYLLA_VERSION}"
+@@ -98,9 +104,15 @@ install-scylla-ccm:
+ 	@echo ${CCM_SCYLLA_VERSION} > ${CCM_CONFIG_DIR}/ccm-version
+
+ .use-development-snk:
+-	@[ -f build/scylladb.snk ] || ( cp build/scylladb-dev.snk build/scylladb.snk )
++	@[ -f build/scylladb.snk ] || ( cp -f build/scylladb-dev.snk build/scylladb.snk )
++
++.prepare-sn-devel:
++	if ! sn -h sn 2>/dev/null >&2; then \
++  		sudo apt-get update; \
++		sudo apt-get install -y mono-devel;\
++	fi
+
+-.use-production-snk:
++.use-production-snk: .prepare-sn-devel
+ 	@if [ -z "${SNK_FILE}" ]; then \
+  		echo "Environment variable SNK_FILE is not set. Please set it to the path of the production SNK file."; \
+  		exit 1; \
+@@ -109,10 +121,10 @@ install-scylla-ccm:
+  	fi; \
+  	sn -p build/scylladb.snk /tmp/scylladb.pub; \
+  	export PROD_SNK_PUBLIC_KEY=`hexdump -v -e '/1 "%02x"' /tmp/scylladb.pub`; \
+- 	echo "Switching to production SNK public key: $$PROD_SNK_PUBLIC_KEY"; \
++ 	echo "Switching to production SNK public key: $${PROD_SNK_PUBLIC_KEY}"; \
+  	for file in `grep --exclude=Makefile -rIl 'PublicKey=' .`; do \
+  	  echo "Processing file: $$file"; \
+- 	  grep 'PublicKey=$$PROD_SNK_PUBLIC_KEY' "$$file" || sed -i "s/PublicKey=${DEV_SNK_PUBLIC_KEY}/PublicKey=$$PROD_SNK_PUBLIC_KEY/g" "$$file" 2> /dev/null 1>&2; \
++ 	  grep 'PublicKey=$${PROD_SNK_PUBLIC_KEY}' "$$file" 2>/dev/null >&1 || sed -i "s/PublicKey=${DEV_SNK_PUBLIC_KEY}/PublicKey=$${PROD_SNK_PUBLIC_KEY}/g" "$$file" 2> /dev/null 1>&2; \
+  	done;
+
+ .target-to-dry-run-package:
+@@ -135,15 +147,18 @@ else
+ 	dotnet nuget push --skip-duplicate "./nupkgs/*.nupkg" --api-key ${NUGET_API_KEY} --source https://api.nuget.org/v3/index.json
+ endif
+
++.PHONY: publish-nuget
+ publish-nuget:
+ 	$(MAKE) .publish-proj-nuget PROJECT_PATH=src/Cassandra/Cassandra.csproj
+ 	$(MAKE) .publish-proj-nuget PROJECT_PATH=src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
+ 	$(MAKE) .publish-proj-nuget PROJECT_PATH=src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+
++.PHONY: publish-nuget-dry-run
+ publish-nuget-dry-run:
+ 	$(MAKE) .publish-proj-nuget PROJECT_PATH=src/Cassandra/Cassandra.csproj DRY_RUN=1
+ 	$(MAKE) .publish-proj-nuget PROJECT_PATH=src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj DRY_RUN=1
+ 	$(MAKE) .publish-proj-nuget PROJECT_PATH=src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj DRY_RUN=1
+
++.PHONY: clean
+ clean:
+ 	find . -name '*.csproj' -print0 | xargs -0 -n1 dotnet clean
+diff --git a/docs/.python-version b/docs/.python-version
+new file mode 100644
+index 00000000..24ee5b1b
+--- /dev/null
++++ b/docs/.python-version
+@@ -0,0 +1 @@
++3.13
+diff --git a/docs/Makefile b/docs/Makefile
+index 4c82ad3b..6fb32383 100644
+--- a/docs/Makefile
++++ b/docs/Makefile
+@@ -1,8 +1,8 @@
+ # Global variables
+ # You can set these variables from the command line.
+-POETRY        = poetry
++UV            = uv
+ SPHINXOPTS    = -j auto
+-SPHINXBUILD   = $(POETRY) run sphinx-build
++SPHINXBUILD   = $(UV) run sphinx-build
+ PAPER         =
+ BUILDDIR      = _build
+ SOURCEDIR     = source
+@@ -19,15 +19,23 @@ all: dirhtml
+ # Setup commands
+ .PHONY: setupenv
+ setupenv:
+-	pip install -q poetry
++	pip install -q uv
++	@if command -v dotnet >/dev/null 2>&1; then \
++		echo "Installing docfx..."; \
++		dotnet tool update -g docfx; \
++	else \
++		echo "Note: .NET SDK not found or not in PATH."; \
++		echo "Install from https://dotnet.microsoft.com/download"; \
++		echo "Then run: dotnet tool update -g docfx"; \
++	fi
+
+ .PHONY: setup
+ setup:
+-	$(POETRY) install
++	$(UV) sync
+
+ .PHONY: update
+ update:
+-	$(POETRY) update
++	$(UV) sync --upgrade
+
+ # Clean commands
+ .PHONY: pristine
+@@ -41,6 +49,7 @@ clean:
+ # Generate output commands
+ .PHONY: dirhtml
+ dirhtml: setup
++	cd .. && ./docs/_utils/docfx.sh
+ 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+ 	@echo
+ 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+@@ -65,24 +74,25 @@ epub3: setup
+
+ .PHONY: multiversion
+ multiversion: setup
+-	$(POETRY) run sphinx-multiversion source $(BUILDDIR)/dirhtml
++	$(UV) run ./_utils/multiversion.sh
+ 	@echo
+ 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+ .PHONY: redirects
+ redirects: setup
+-	$(POETRY) run redirects-cli fromfile --yaml-file _utils/redirects.yaml --output-dir $(BUILDDIR)/dirhtml
++	$(UV) run redirects-cli fromfile --yaml-file _utils/redirects.yaml --output-dir $(BUILDDIR)/dirhtml
+ 	@echo
+ 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+ # Preview commands
+ .PHONY: preview
+ preview: setup
+-	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
++	cd .. && ./docs/_utils/docfx.sh
++	$(UV) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
+
+ .PHONY: multiversionpreview
+ multiversionpreview: multiversion
+-	$(POETRY) run python -m http.server 5500 --directory $(BUILDDIR)/dirhtml
++	$(UV) run python3 -m http.server 5500 --directory $(BUILDDIR)/dirhtml
+
+ # Test commands
+ .PHONY: test
+diff --git a/docs/README.md b/docs/README.md
+new file mode 100644
+index 00000000..438c51f1
+--- /dev/null
++++ b/docs/README.md
+@@ -0,0 +1,33 @@
++# ScyllaDB C# Driver Documentation
++
++This directory contains the documentation for the ScyllaDB C# Driver, built with Sphinx and integrated with DocFX for API reference generation.
++
++## Prerequisites
++
++- Python 3.10+
++- [Poetry](https://python-poetry.org/) - Python dependency management
++- [.NET SDK 8.0+](https://dotnet.microsoft.com/download) - For API documentation generation
++- [DocFX 2.77+](https://dotnet.github.io/docfx/) - C# API documentation tool
++
++## Quickstart
++
++Install dependencies (first time only):
++
++```bash
++# Install poetry and docfx
++make setupenv
++```
++
++Preview the documentation locally:
++
++```bash
++make preview
++```
++
++## API Documentation
++
++The API reference is generated with DocFX and available at:
++- Local preview: `http://localhost:5500/api-docs/`
++- Build output: `_build/dirhtml/api-docs/`
++
++**Note:** If DocFX is not installed, the build will succeed but skip API documentation generation.
+diff --git a/docs/_utils/docfx.sh b/docs/_utils/docfx.sh
+new file mode 100755
+index 00000000..4bc90902
+--- /dev/null
++++ b/docs/_utils/docfx.sh
+@@ -0,0 +1,40 @@
++#!/bin/bash
++
++# Check if docfx is available
++if ! command -v docfx &> /dev/null; then
++    echo "Warning: docfx not found. Skipping API documentation generation."
++    echo "Install with: dotnet tool update -g docfx"
++    exit 0
++fi
++
++# Ensure the signing key exists for docfx builds
++# The scylladb.snk file is gitignored, so use the dev key
++if [ ! -f "build/scylladb.snk" ]; then
++    echo "Using scylladb-dev.snk for documentation build..."
++    cp build/scylladb-dev.snk build/scylladb.snk
++fi
++
++# Navigate to the api-docs directory where docfx.json is located
++cd docs/source/api-docs
++
++# Define output folder
++OUTPUT_DIR="../../_build/dirhtml/api-docs"
++if [[ "$SPHINX_MULTIVERSION_OUTPUTDIR" != "" ]]; then
++    OUTPUT_DIR="$SPHINX_MULTIVERSION_OUTPUTDIR/api-docs"
++fi
++
++# Generate API documentation with docfx
++echo "Generating API documentation with docfx..."
++docfx metadata docfx.json
++docfx build docfx.json
++
++# Move the built API docs to the output directory
++[ -d "$OUTPUT_DIR" ] && rm -r "$OUTPUT_DIR"
++mkdir -p "$OUTPUT_DIR"
++if [ -d "api-docs" ]; then
++    mv -f api-docs/* "$OUTPUT_DIR/"
++    echo "API documentation generated successfully at $OUTPUT_DIR"
++else
++    echo "Warning: api-docs directory not found after docfx build"
++fi
++
+diff --git a/docs/_utils/multiversion.sh b/docs/_utils/multiversion.sh
+new file mode 100755
+index 00000000..c2ec693a
+--- /dev/null
++++ b/docs/_utils/multiversion.sh
+@@ -0,0 +1,6 @@
++#!/bin/bash
++
++cd .. && sphinx-multiversion docs/source docs/_build/dirhtml \
++    --pre-build './docs/_utils/docfx.sh'
++
++
+diff --git a/docs/poetry.lock b/docs/poetry.lock
+deleted file mode 100644
+index 63ad15b1..00000000
+--- a/docs/poetry.lock
++++ /dev/null
+@@ -1,1312 +0,0 @@
+-# This file is automatically @generated by Poetry 2.2.0 and should not be changed by hand.
+-
+-[[package]]
+-name = "alabaster"
+-version = "1.0.0"
+-description = "A light, configurable Sphinx theme"
+-optional = false
+-python-versions = ">=3.10"
+-groups = ["main"]
+-files = [
+-    {file = "alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"},
+-    {file = "alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e"},
+-]
+-
+-[[package]]
+-name = "anyio"
+-version = "4.10.0"
+-description = "High-level concurrency and networking framework on top of asyncio or Trio"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1"},
+-    {file = "anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6"},
+-]
+-
+-[package.dependencies]
+-idna = ">=2.8"
+-sniffio = ">=1.1"
+-
+-[package.extras]
+-trio = ["trio (>=0.26.1)"]
+-
+-[[package]]
+-name = "babel"
+-version = "2.17.0"
+-description = "Internationalization utilities"
+-optional = false
+-python-versions = ">=3.8"
+-groups = ["main"]
+-files = [
+-    {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"},
+-    {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d"},
+-]
+-
+-[package.extras]
+-dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+-
+-[[package]]
+-name = "beartype"
+-version = "0.21.0"
+-description = "Unbearably fast near-real-time hybrid runtime-static type-checking in pure Python."
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "beartype-0.21.0-py3-none-any.whl", hash = "sha256:b6a1bd56c72f31b0a496a36cc55df6e2f475db166ad07fa4acc7e74f4c7f34c0"},
+-    {file = "beartype-0.21.0.tar.gz", hash = "sha256:f9a5078f5ce87261c2d22851d19b050b64f6a805439e8793aecf01ce660d3244"},
+-]
+-
+-[package.extras]
+-dev = ["autoapi (>=0.9.0)", "click", "coverage (>=5.5)", "equinox ; sys_platform == \"linux\"", "jax[cpu] ; sys_platform == \"linux\"", "jaxtyping ; sys_platform == \"linux\"", "langchain", "mypy (>=0.800) ; platform_python_implementation != \"PyPy\"", "nuitka (>=1.2.6) ; sys_platform == \"linux\"", "numba ; python_version < \"3.13.0\"", "numpy ; sys_platform != \"darwin\" and platform_python_implementation != \"PyPy\"", "pandera", "pydata-sphinx-theme (<=0.7.2)", "pygments", "pyright (>=1.1.370)", "pytest (>=4.0.0)", "rich-click", "sphinx", "sphinx (>=4.2.0,<6.0.0)", "sphinxext-opengraph (>=0.7.5)", "sqlalchemy", "tox (>=3.20.1)", "typing-extensions (>=3.10.0.0)", "xarray"]
+-doc-rtd = ["autoapi (>=0.9.0)", "pydata-sphinx-theme (<=0.7.2)", "sphinx (>=4.2.0,<6.0.0)", "sphinxext-opengraph (>=0.7.5)"]
+-test = ["click", "coverage (>=5.5)", "equinox ; sys_platform == \"linux\"", "jax[cpu] ; sys_platform == \"linux\"", "jaxtyping ; sys_platform == \"linux\"", "langchain", "mypy (>=0.800) ; platform_python_implementation != \"PyPy\"", "nuitka (>=1.2.6) ; sys_platform == \"linux\"", "numba ; python_version < \"3.13.0\"", "numpy ; sys_platform != \"darwin\" and platform_python_implementation != \"PyPy\"", "pandera", "pygments", "pyright (>=1.1.370)", "pytest (>=4.0.0)", "rich-click", "sphinx", "sqlalchemy", "tox (>=3.20.1)", "typing-extensions (>=3.10.0.0)", "xarray"]
+-test-tox = ["click", "equinox ; sys_platform == \"linux\"", "jax[cpu] ; sys_platform == \"linux\"", "jaxtyping ; sys_platform == \"linux\"", "langchain", "mypy (>=0.800) ; platform_python_implementation != \"PyPy\"", "nuitka (>=1.2.6) ; sys_platform == \"linux\"", "numba ; python_version < \"3.13.0\"", "numpy ; sys_platform != \"darwin\" and platform_python_implementation != \"PyPy\"", "pandera", "pygments", "pyright (>=1.1.370)", "pytest (>=4.0.0)", "rich-click", "sphinx", "sqlalchemy", "typing-extensions (>=3.10.0.0)", "xarray"]
+-test-tox-coverage = ["coverage (>=5.5)"]
+-
+-[[package]]
+-name = "beautifulsoup4"
+-version = "4.13.5"
+-description = "Screen-scraping library"
+-optional = false
+-python-versions = ">=3.7.0"
+-groups = ["main"]
+-files = [
+-    {file = "beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a"},
+-    {file = "beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695"},
+-]
+-
+-[package.dependencies]
+-soupsieve = ">1.2"
+-typing-extensions = ">=4.0.0"
+-
+-[package.extras]
+-cchardet = ["cchardet"]
+-chardet = ["chardet"]
+-charset-normalizer = ["charset-normalizer"]
+-html5lib = ["html5lib"]
+-lxml = ["lxml"]
+-
+-[[package]]
+-name = "certifi"
+-version = "2025.8.3"
+-description = "Python package for providing Mozilla's CA Bundle."
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
+-    {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
+-]
+-
+-[[package]]
+-name = "charset-normalizer"
+-version = "3.4.3"
+-description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fb7f67a1bfa6e40b438170ebdc8158b78dc465a5a67b6dde178a46987b244a72"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc9370a2da1ac13f0153780040f465839e6cccb4a1e44810124b4e22483c93fe"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:07a0eae9e2787b586e129fdcbe1af6997f8d0e5abaa0bc98c0e20e124d67e601"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:74d77e25adda8581ffc1c720f1c81ca082921329452eba58b16233ab1842141c"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0e909868420b7049dafd3a31d45125b31143eec59235311fc4c57ea26a4acd2"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c6f162aabe9a91a309510d74eeb6507fab5fff92337a15acbe77753d88d9dcf0"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4ca4c094de7771a98d7fbd67d9e5dbf1eb73efa4f744a730437d8a3a5cf994f0"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:02425242e96bcf29a49711b0ca9f37e451da7c70562bc10e8ed992a5a7a25cc0"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:78deba4d8f9590fe4dae384aeff04082510a709957e968753ff3c48399f6f92a"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-win32.whl", hash = "sha256:d79c198e27580c8e958906f803e63cddb77653731be08851c7df0b1a14a8fc0f"},
+-    {file = "charset_normalizer-3.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:c6e490913a46fa054e03699c70019ab869e990270597018cef1d8562132c2669"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b256ee2e749283ef3ddcff51a675ff43798d92d746d1a6e4631bf8c707d22d0b"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13faeacfe61784e2559e690fc53fa4c5ae97c6fcedb8eb6fb8d0a15b475d2c64"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:00237675befef519d9af72169d8604a067d92755e84fe76492fef5441db05b91"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:585f3b2a80fbd26b048a0be90c5aae8f06605d3c92615911c3a2b03a8a3b796f"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e78314bdc32fa80696f72fa16dc61168fda4d6a0c014e0380f9d02f0e5d8a07"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:96b2b3d1a83ad55310de8c7b4a2d04d9277d5591f40761274856635acc5fcb30"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:939578d9d8fd4299220161fdd76e86c6a251987476f5243e8864a7844476ba14"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:fd10de089bcdcd1be95a2f73dbe6254798ec1bda9f450d5828c96f93e2536b9c"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1e8ac75d72fa3775e0b7cb7e4629cec13b7514d928d15ef8ea06bca03ef01cae"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-win32.whl", hash = "sha256:6cf8fd4c04756b6b60146d98cd8a77d0cdae0e1ca20329da2ac85eed779b6849"},
+-    {file = "charset_normalizer-3.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:31a9a6f775f9bcd865d88ee350f0ffb0e25936a7f930ca98995c05abf1faf21c"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-win32.whl", hash = "sha256:fb6fecfd65564f208cbf0fba07f107fb661bcd1a7c389edbced3f7a493f70e37"},
+-    {file = "charset_normalizer-3.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:86df271bf921c2ee3818f0522e9a5b8092ca2ad8b065ece5d7d9d0e9f4849bcc"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce"},
+-    {file = "charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce"},
+-    {file = "charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:0f2be7e0cf7754b9a30eb01f4295cc3d4358a479843b31f328afd210e2c7598c"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c60e092517a73c632ec38e290eba714e9627abe9d301c8c8a12ec32c314a2a4b"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:252098c8c7a873e17dd696ed98bbe91dbacd571da4b87df3736768efa7a792e4"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3653fad4fe3ed447a596ae8638b437f827234f01a8cd801842e43f3d0a6b281b"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8999f965f922ae054125286faf9f11bc6932184b93011d138925a1773830bbe9"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d95bfb53c211b57198bb91c46dd5a2d8018b3af446583aab40074bf7988401cb"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:5b413b0b1bfd94dbf4023ad6945889f374cd24e3f62de58d6bb102c4d9ae534a"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:b5e3b2d152e74e100a9e9573837aba24aab611d39428ded46f4e4022ea7d1942"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a2d08ac246bb48479170408d6c19f6385fa743e7157d716e144cad849b2dd94b"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-win32.whl", hash = "sha256:ec557499516fc90fd374bf2e32349a2887a876fbf162c160e3c01b6849eaf557"},
+-    {file = "charset_normalizer-3.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:5d8d01eac18c423815ed4f4a2ec3b439d654e55ee4ad610e153cf02faf67ea40"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:70bfc5f2c318afece2f5838ea5e4c3febada0be750fcf4775641052bbba14d05"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23b6b24d74478dc833444cbd927c338349d6ae852ba53a0d02a2de1fce45b96e"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:34a7f768e3f985abdb42841e20e17b330ad3aaf4bb7e7aeeb73db2e70f077b99"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb731e5deb0c7ef82d698b0f4c5bb724633ee2a489401594c5c88b02e6cb15f7"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:257f26fed7d7ff59921b78244f3cd93ed2af1800ff048c33f624c87475819dd7"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1ef99f0456d3d46a50945c98de1774da86f8e992ab5c77865ea8b8195341fc19"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2c322db9c8c89009a990ef07c3bcc9f011a3269bc06782f916cd3d9eed7c9312"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:511729f456829ef86ac41ca78c63a5cb55240ed23b4b737faca0eb1abb1c41bc"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:88ab34806dea0671532d3f82d82b85e8fc23d7b2dd12fa837978dad9bb392a34"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-win32.whl", hash = "sha256:16a8770207946ac75703458e2c743631c79c59c5890c80011d536248f8eaa432"},
+-    {file = "charset_normalizer-3.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:d22dbedd33326a4a5190dd4fe9e9e693ef12160c77382d9e87919bce54f3d4ca"},
+-    {file = "charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a"},
+-    {file = "charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14"},
+-]
+-
+-[[package]]
+-name = "click"
+-version = "8.3.0"
+-description = "Composable command line interface toolkit"
+-optional = false
+-python-versions = ">=3.10"
+-groups = ["main"]
+-files = [
+-    {file = "click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc"},
+-    {file = "click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"},
+-]
+-
+-[package.dependencies]
+-colorama = {version = "*", markers = "platform_system == \"Windows\""}
+-
+-[[package]]
+-name = "colorama"
+-version = "0.4.6"
+-description = "Cross-platform colored terminal text."
+-optional = false
+-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+-groups = ["main"]
+-files = [
+-    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+-    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+-]
+-
+-[[package]]
+-name = "docutils"
+-version = "0.21.2"
+-description = "Docutils -- Python Documentation Utilities"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2"},
+-    {file = "docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"},
+-]
+-
+-[[package]]
+-name = "h11"
+-version = "0.16.0"
+-description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+-optional = false
+-python-versions = ">=3.8"
+-groups = ["main"]
+-files = [
+-    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+-    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+-]
+-
+-[[package]]
+-name = "idna"
+-version = "3.10"
+-description = "Internationalized Domain Names in Applications (IDNA)"
+-optional = false
+-python-versions = ">=3.6"
+-groups = ["main"]
+-files = [
+-    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+-    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+-]
+-
+-[package.extras]
+-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+-
+-[[package]]
+-name = "imagesize"
+-version = "1.4.1"
+-description = "Getting image size from png/jpeg/jpeg2000/gif file"
+-optional = false
+-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+-groups = ["main"]
+-files = [
+-    {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
+-    {file = "imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"},
+-]
+-
+-[[package]]
+-name = "jinja2"
+-version = "3.1.6"
+-description = "A very fast and expressive template engine."
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+-    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
+-]
+-
+-[package.dependencies]
+-MarkupSafe = ">=2.0"
+-
+-[package.extras]
+-i18n = ["Babel (>=2.7)"]
+-
+-[[package]]
+-name = "markdown-it-py"
+-version = "3.0.0"
+-description = "Python port of markdown-it. Markdown parsing, done right!"
+-optional = false
+-python-versions = ">=3.8"
+-groups = ["main"]
+-files = [
+-    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+-    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+-]
+-
+-[package.dependencies]
+-mdurl = ">=0.1,<1.0"
+-
+-[package.extras]
+-benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+-code-style = ["pre-commit (>=3.0,<4.0)"]
+-compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+-linkify = ["linkify-it-py (>=1,<3)"]
+-plugins = ["mdit-py-plugins"]
+-profiling = ["gprof2dot"]
+-rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+-testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+-
+-[[package]]
+-name = "markupsafe"
+-version = "3.0.2"
+-description = "Safely add untrusted strings to HTML/XML markup."
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50"},
+-    {file = "MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d"},
+-    {file = "MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30"},
+-    {file = "MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6"},
+-    {file = "MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f"},
+-    {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
+-    {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
+-]
+-
+-[[package]]
+-name = "mdit-py-plugins"
+-version = "0.5.0"
+-description = "Collection of plugins for markdown-it-py"
+-optional = false
+-python-versions = ">=3.10"
+-groups = ["main"]
+-files = [
+-    {file = "mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f"},
+-    {file = "mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6"},
+-]
+-
+-[package.dependencies]
+-markdown-it-py = ">=2.0.0,<5.0.0"
+-
+-[package.extras]
+-code-style = ["pre-commit"]
+-rtd = ["myst-parser", "sphinx-book-theme"]
+-testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+-
+-[[package]]
+-name = "mdurl"
+-version = "0.1.2"
+-description = "Markdown URL utilities"
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+-    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+-]
+-
+-[[package]]
+-name = "myst-parser"
+-version = "4.0.1"
+-description = "An extended [CommonMark](https://spec.commonmark.org/) compliant parser,"
+-optional = false
+-python-versions = ">=3.10"
+-groups = ["main"]
+-files = [
+-    {file = "myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d"},
+-    {file = "myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4"},
+-]
+-
+-[package.dependencies]
+-docutils = ">=0.19,<0.22"
+-jinja2 = "*"
+-markdown-it-py = ">=3.0,<4.0"
+-mdit-py-plugins = ">=0.4.1,<1.0"
+-pyyaml = "*"
+-sphinx = ">=7,<9"
+-
+-[package.extras]
+-code-style = ["pre-commit (>=4.0,<5.0)"]
+-linkify = ["linkify-it-py (>=2.0,<3.0)"]
+-rtd = ["ipython", "sphinx (>=7)", "sphinx-autodoc2 (>=0.5.0,<0.6.0)", "sphinx-book-theme (>=1.1,<2.0)", "sphinx-copybutton", "sphinx-design", "sphinx-pyscript", "sphinx-tippy (>=0.4.3)", "sphinx-togglebutton", "sphinxext-opengraph (>=0.9.0,<0.10.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
+-testing = ["beautifulsoup4", "coverage[toml]", "defusedxml", "pygments (<2.19)", "pytest (>=8,<9)", "pytest-cov", "pytest-param-files (>=0.6.0,<0.7.0)", "pytest-regressions", "sphinx-pytest"]
+-testing-docutils = ["pygments", "pytest (>=8,<9)", "pytest-param-files (>=0.6.0,<0.7.0)"]
+-
+-[[package]]
+-name = "packaging"
+-version = "25.0"
+-description = "Core utilities for Python packages"
+-optional = false
+-python-versions = ">=3.8"
+-groups = ["main"]
+-files = [
+-    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
+-    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
+-]
+-
+-[[package]]
+-name = "pygments"
+-version = "2.19.2"
+-description = "Pygments is a syntax highlighting package written in Python."
+-optional = false
+-python-versions = ">=3.8"
+-groups = ["main"]
+-files = [
+-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
+-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+-]
+-
+-[package.extras]
+-windows-terminal = ["colorama (>=0.4.6)"]
+-
+-[[package]]
+-name = "pyyaml"
+-version = "6.0.2"
+-description = "YAML parser and emitter for Python"
+-optional = false
+-python-versions = ">=3.8"
+-groups = ["main"]
+-files = [
+-    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+-    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+-    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+-    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+-    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+-    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+-    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+-    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+-    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+-    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+-    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+-    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+-    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+-    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+-    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+-    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+-    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+-]
+-
+-[[package]]
+-name = "redirects-cli"
+-version = "0.1.3"
+-description = "Generates static redirections from a YAML file."
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "redirects_cli-0.1.3-py3-none-any.whl", hash = "sha256:8a7a548d5f45b98db7d110fd8affbbb44b966cf250e35b5f4c9bd6541622272d"},
+-    {file = "redirects_cli-0.1.3.tar.gz", hash = "sha256:0cc6f35ae372d087d56bc03cfc639d6e2eac0771454c3c173ac6f3dc233969bc"},
+-]
+-
+-[package.dependencies]
+-colorama = ">=0.4"
+-typer = ">=0.3"
+-
+-[package.extras]
+-test = ["pre-commit", "pytest"]
+-
+-[[package]]
+-name = "requests"
+-version = "2.32.5"
+-description = "Python HTTP for Humans."
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
+-    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
+-]
+-
+-[package.dependencies]
+-certifi = ">=2017.4.17"
+-charset_normalizer = ">=2,<4"
+-idna = ">=2.5,<4"
+-urllib3 = ">=1.21.1,<3"
+-
+-[package.extras]
+-socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+-
+-[[package]]
+-name = "rich"
+-version = "14.1.0"
+-description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+-optional = false
+-python-versions = ">=3.8.0"
+-groups = ["main"]
+-files = [
+-    {file = "rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f"},
+-    {file = "rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8"},
+-]
+-
+-[package.dependencies]
+-markdown-it-py = ">=2.2.0"
+-pygments = ">=2.13.0,<3.0.0"
+-
+-[package.extras]
+-jupyter = ["ipywidgets (>=7.5.1,<9)"]
+-
+-[[package]]
+-name = "roman-numerals-py"
+-version = "3.1.0"
+-description = "Manipulate well-formed Roman numerals"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c"},
+-    {file = "roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d"},
+-]
+-
+-[package.extras]
+-lint = ["mypy (==1.15.0)", "pyright (==1.1.394)", "ruff (==0.9.7)"]
+-test = ["pytest (>=8)"]
+-
+-[[package]]
+-name = "setuptools"
+-version = "80.9.0"
+-description = "Easily download, build, install, upgrade, and uninstall Python packages"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
+-    {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
+-]
+-
+-[package.extras]
+-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
+-core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+-cover = ["pytest-cov"]
+-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+-enabler = ["pytest-enabler (>=2.2)"]
+-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
+-
+-[[package]]
+-name = "shellingham"
+-version = "1.5.4"
+-description = "Tool to Detect Surrounding Shell"
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+-    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+-]
+-
+-[[package]]
+-name = "sniffio"
+-version = "1.3.1"
+-description = "Sniff out which async library your code is running under"
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+-    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+-]
+-
+-[[package]]
+-name = "snowballstemmer"
+-version = "3.0.1"
+-description = "This package provides 32 stemmers for 30 languages generated from Snowball algorithms."
+-optional = false
+-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*"
+-groups = ["main"]
+-files = [
+-    {file = "snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064"},
+-    {file = "snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895"},
+-]
+-
+-[[package]]
+-name = "soupsieve"
+-version = "2.8"
+-description = "A modern CSS selector implementation for Beautiful Soup."
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c"},
+-    {file = "soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f"},
+-]
+-
+-[[package]]
+-name = "sphinx"
+-version = "8.2.3"
+-description = "Python documentation generator"
+-optional = false
+-python-versions = ">=3.11"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3"},
+-    {file = "sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348"},
+-]
+-
+-[package.dependencies]
+-alabaster = ">=0.7.14"
+-babel = ">=2.13"
+-colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
+-docutils = ">=0.20,<0.22"
+-imagesize = ">=1.3"
+-Jinja2 = ">=3.1"
+-packaging = ">=23.0"
+-Pygments = ">=2.17"
+-requests = ">=2.30.0"
+-roman-numerals-py = ">=1.0.0"
+-snowballstemmer = ">=2.2"
+-sphinxcontrib-applehelp = ">=1.0.7"
+-sphinxcontrib-devhelp = ">=1.0.6"
+-sphinxcontrib-htmlhelp = ">=2.0.6"
+-sphinxcontrib-jsmath = ">=1.0.1"
+-sphinxcontrib-qthelp = ">=1.0.6"
+-sphinxcontrib-serializinghtml = ">=1.1.9"
+-
+-[package.extras]
+-docs = ["sphinxcontrib-websupport"]
+-lint = ["betterproto (==2.0.0b6)", "mypy (==1.15.0)", "pypi-attestations (==0.0.21)", "pyright (==1.1.395)", "pytest (>=8.0)", "ruff (==0.9.9)", "sphinx-lint (>=0.9)", "types-Pillow (==10.2.0.20240822)", "types-Pygments (==2.19.0.20250219)", "types-colorama (==0.4.15.20240311)", "types-defusedxml (==0.7.0.20240218)", "types-docutils (==0.21.0.20241128)", "types-requests (==2.32.0.20241016)", "types-urllib3 (==1.26.25.14)"]
+-test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "pytest-xdist[psutil] (>=3.4)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
+-
+-[[package]]
+-name = "sphinx-autobuild"
+-version = "2025.8.25"
+-description = "Rebuild Sphinx documentation on changes, with hot reloading in the browser."
+-optional = false
+-python-versions = ">=3.11"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx_autobuild-2025.8.25-py3-none-any.whl", hash = "sha256:b750ac7d5a18603e4665294323fd20f6dcc0a984117026d1986704fa68f0379a"},
+-    {file = "sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213"},
+-]
+-
+-[package.dependencies]
+-colorama = ">=0.4.6"
+-Sphinx = "*"
+-starlette = ">=0.35"
+-uvicorn = ">=0.25"
+-watchfiles = ">=0.20"
+-websockets = ">=11"
+-
+-[package.extras]
+-test = ["httpx", "pytest (>=6)"]
+-
+-[[package]]
+-name = "sphinx-collapse"
+-version = "0.1.3"
+-description = "Collapse extension for Sphinx."
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx_collapse-0.1.3-py3-none-any.whl", hash = "sha256:85fadb2ec8769b93fd04276538668fa96239ef60c20c4a9eaa3e480387a6e65b"},
+-    {file = "sphinx_collapse-0.1.3.tar.gz", hash = "sha256:cae141e6f03ecd52ed246a305a69e1b0d5d05e6cdf3fe803d40d583ad6ad895a"},
+-]
+-
+-[package.dependencies]
+-sphinx = ">=3"
+-
+-[package.extras]
+-doc = ["alabaster"]
+-test = ["pre-commit", "pytest"]
+-
+-[[package]]
+-name = "sphinx-copybutton"
+-version = "0.5.2"
+-description = "Add a copy button to each of your code cells."
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd"},
+-    {file = "sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e"},
+-]
+-
+-[package.dependencies]
+-sphinx = ">=1.8"
+-
+-[package.extras]
+-code-style = ["pre-commit (==2.12.1)"]
+-rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
+-
+-[[package]]
+-name = "sphinx-last-updated-by-git"
+-version = "0.3.8"
+-description = "Get the \"last updated\" time for each Sphinx page from Git"
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx_last_updated_by_git-0.3.8-py3-none-any.whl", hash = "sha256:6382c8285ac1f222483a58569b78c0371af5e55f7fbf9c01e5e8a72d6fdfa499"},
+-    {file = "sphinx_last_updated_by_git-0.3.8.tar.gz", hash = "sha256:c145011f4609d841805b69a9300099fc02fed8f5bb9e5bcef77d97aea97b7761"},
+-]
+-
+-[package.dependencies]
+-sphinx = ">=1.8"
+-
+-[[package]]
+-name = "sphinx-multiversion-scylla"
+-version = "0.3.2"
+-description = "Add support for multiple versions to sphinx"
+-optional = false
+-python-versions = "*"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx_multiversion_scylla-0.3.2.tar.gz", hash = "sha256:f415311273228f4f766c36256503da8e2ce01f9d13423f3fcee3160d6284852b"},
+-]
+-
+-[package.dependencies]
+-sphinx = ">=2.1"
+-
+-[[package]]
+-name = "sphinx-notfound-page"
+-version = "1.1.0"
+-description = "Sphinx extension to build a 404 page with absolute URLs"
+-optional = false
+-python-versions = ">=3.8"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx_notfound_page-1.1.0-py3-none-any.whl", hash = "sha256:835dc76ff7914577a1f58d80a2c8418fb6138c0932c8da8adce4d9096fbcd389"},
+-    {file = "sphinx_notfound_page-1.1.0.tar.gz", hash = "sha256:913e1754370bb3db201d9300d458a8b8b5fb22e9246a816643a819a9ea2b8067"},
+-]
+-
+-[package.dependencies]
+-sphinx = ">=5"
+-
+-[package.extras]
+-doc = ["sphinx-autoapi", "sphinx-rtd-theme", "sphinx-tabs", "sphinxemoji"]
+-test = ["tox"]
+-
+-[[package]]
+-name = "sphinx-scylladb-theme"
+-version = "1.8.8"
+-description = "A Sphinx Theme for ScyllaDB documentation projects"
+-optional = false
+-python-versions = "<4.0,>=3.10"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx_scylladb_theme-1.8.8-py3-none-any.whl", hash = "sha256:9b37f58b745bfc818b6f0869cbcc414a3ad6658023b22a6abbec44da5c09cf80"},
+-    {file = "sphinx_scylladb_theme-1.8.8.tar.gz", hash = "sha256:15af599424f8b2ddbf14644b267c0bd31bc3fbbd64bca5b97d7b31bdb84d2c3d"},
+-]
+-
+-[package.dependencies]
+-beautifulsoup4 = ">=4.12.3,<5.0.0"
+-pyyaml = ">=6.0.1,<7.0.0"
+-setuptools = ">=70.1.1,<81.0.0"
+-sphinx-collapse = ">=0.1.1,<0.2.0"
+-sphinx-copybutton = ">=0.5.2,<0.6.0"
+-sphinx-notfound-page = ">=1.0.4,<2.0.0"
+-Sphinx-Substitution-Extensions = ">=2022.2.16,<2026.0.0"
+-sphinx-tabs = ">=3.4.5,<4.0.0"
+-sphinxcontrib-mermaid = ">=1.0.0,<2.0.0"
+-
+-[[package]]
+-name = "sphinx-sitemap"
+-version = "2.8.0"
+-description = "Sitemap generator for Sphinx"
+-optional = false
+-python-versions = "*"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx_sitemap-2.8.0-py3-none-any.whl", hash = "sha256:332042cd5b9385f61ec2861dfd550d9bccbdfcff86f6b68c7072cf40c9f16363"},
+-    {file = "sphinx_sitemap-2.8.0.tar.gz", hash = "sha256:749d7184a0c7b73d486a232b54b5c1b38a0e2d6f18cf19fb1b033b8162b44a82"},
+-]
+-
+-[package.dependencies]
+-sphinx-last-updated-by-git = "*"
+-
+-[package.extras]
+-dev = ["build", "flake8", "pre-commit", "pytest", "sphinx", "sphinx-last-updated-by-git", "tox"]
+-
+-[[package]]
+-name = "sphinx-substitution-extensions"
+-version = "2025.6.6"
+-description = "Extensions for Sphinx which allow for substitutions."
+-optional = false
+-python-versions = ">=3.10"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx_substitution_extensions-2025.6.6-py2.py3-none-any.whl", hash = "sha256:96206ba7a2cdf43237edec81f87770a5683a91a1de3bf93f7a22309509ecbfd8"},
+-    {file = "sphinx_substitution_extensions-2025.6.6.tar.gz", hash = "sha256:241ddb9f88962422a8b436243d2601f9d94616e94b520ce1a6a528d9a3b7804a"},
+-]
+-
+-[package.dependencies]
+-beartype = ">=0.18.5"
+-docutils = ">=0.19"
+-myst-parser = ">=4.0.0"
+-sphinx = ">=8.1.0"
+-
+-[package.extras]
+-dev = ["actionlint-py (==1.7.7.23)", "check-manifest (==0.50)", "deptry (==0.23.0)", "doc8 (==1.1.2)", "doccmd (==2025.4.8)", "docformatter (==1.7.7)", "interrogate (==1.7.0)", "mypy-strict-kwargs (==2025.4.3)", "mypy[faster-cache] (==1.16.0)", "pre-commit (==4.2.0)", "pyenchant (==3.3.0rc1)", "pylint (==3.3.7)", "pyproject-fmt (==2.6.0)", "pyright (==1.1.401)", "pyroma (==4.2)", "pytest (==8.4.0)", "pytest-cov (==6.1.1)", "ruff (==0.11.13)", "shellcheck-py (==0.10.0.1)", "shfmt-py (==3.11.0.2)", "sphinx-lint (==1.0.0)", "sphinx-toolbox (==4.0.0)", "types-docutils (==0.21.0.20250604)", "vulture (==2.14)", "yamlfix (==1.17.0)"]
+-release = ["check-wheel-contents (==0.6.2)"]
+-
+-[[package]]
+-name = "sphinx-tabs"
+-version = "3.4.7"
+-description = "Tabbed views for Sphinx"
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "sphinx-tabs-3.4.7.tar.gz", hash = "sha256:991ad4a424ff54119799ba1491701aa8130dd43509474aef45a81c42d889784d"},
+-    {file = "sphinx_tabs-3.4.7-py3-none-any.whl", hash = "sha256:c12d7a36fd413b369e9e9967a0a4015781b71a9c393575419834f19204bd1915"},
+-]
+-
+-[package.dependencies]
+-docutils = "*"
+-pygments = "*"
+-sphinx = ">=1.8"
+-
+-[package.extras]
+-code-style = ["pre-commit (==2.13.0)"]
+-testing = ["bs4", "coverage", "pygments", "pytest (>=7.1,<8)", "pytest-cov", "pytest-regressions", "rinohtype"]
+-
+-[[package]]
+-name = "sphinxcontrib-applehelp"
+-version = "2.0.0"
+-description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5"},
+-    {file = "sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1"},
+-]
+-
+-[package.extras]
+-lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+-standalone = ["Sphinx (>=5)"]
+-test = ["pytest"]
+-
+-[[package]]
+-name = "sphinxcontrib-devhelp"
+-version = "2.0.0"
+-description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2"},
+-    {file = "sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad"},
+-]
+-
+-[package.extras]
+-lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+-standalone = ["Sphinx (>=5)"]
+-test = ["pytest"]
+-
+-[[package]]
+-name = "sphinxcontrib-htmlhelp"
+-version = "2.1.0"
+-description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8"},
+-    {file = "sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9"},
+-]
+-
+-[package.extras]
+-lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+-standalone = ["Sphinx (>=5)"]
+-test = ["html5lib", "pytest"]
+-
+-[[package]]
+-name = "sphinxcontrib-jsmath"
+-version = "1.0.1"
+-description = "A sphinx extension which renders display math in HTML via JavaScript"
+-optional = false
+-python-versions = ">=3.5"
+-groups = ["main"]
+-files = [
+-    {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
+-    {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
+-]
+-
+-[package.extras]
+-test = ["flake8", "mypy", "pytest"]
+-
+-[[package]]
+-name = "sphinxcontrib-mermaid"
+-version = "1.0.0"
+-description = "Mermaid diagrams in yours Sphinx powered docs"
+-optional = false
+-python-versions = ">=3.8"
+-groups = ["main"]
+-files = [
+-    {file = "sphinxcontrib_mermaid-1.0.0-py3-none-any.whl", hash = "sha256:60b72710ea02087f212028feb09711225fbc2e343a10d34822fe787510e1caa3"},
+-    {file = "sphinxcontrib_mermaid-1.0.0.tar.gz", hash = "sha256:2e8ab67d3e1e2816663f9347d026a8dee4a858acdd4ad32dd1c808893db88146"},
+-]
+-
+-[package.dependencies]
+-pyyaml = "*"
+-sphinx = "*"
+-
+-[package.extras]
+-test = ["defusedxml", "myst-parser", "pytest", "ruff", "sphinx"]
+-
+-[[package]]
+-name = "sphinxcontrib-qthelp"
+-version = "2.0.0"
+-description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb"},
+-    {file = "sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab"},
+-]
+-
+-[package.extras]
+-lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+-standalone = ["Sphinx (>=5)"]
+-test = ["defusedxml (>=0.7.1)", "pytest"]
+-
+-[[package]]
+-name = "sphinxcontrib-serializinghtml"
+-version = "2.0.0"
+-description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331"},
+-    {file = "sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"},
+-]
+-
+-[package.extras]
+-lint = ["mypy", "ruff (==0.5.5)", "types-docutils"]
+-standalone = ["Sphinx (>=5)"]
+-test = ["pytest"]
+-
+-[[package]]
+-name = "starlette"
+-version = "0.48.0"
+-description = "The little ASGI library that shines."
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659"},
+-    {file = "starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46"},
+-]
+-
+-[package.dependencies]
+-anyio = ">=3.6.2,<5"
+-
+-[package.extras]
+-full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+-
+-[[package]]
+-name = "typer"
+-version = "0.17.4"
+-description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+-optional = false
+-python-versions = ">=3.7"
+-groups = ["main"]
+-files = [
+-    {file = "typer-0.17.4-py3-none-any.whl", hash = "sha256:015534a6edaa450e7007eba705d5c18c3349dcea50a6ad79a5ed530967575824"},
+-    {file = "typer-0.17.4.tar.gz", hash = "sha256:b77dc07d849312fd2bb5e7f20a7af8985c7ec360c45b051ed5412f64d8dc1580"},
+-]
+-
+-[package.dependencies]
+-click = ">=8.0.0"
+-rich = ">=10.11.0"
+-shellingham = ">=1.3.0"
+-typing-extensions = ">=3.7.4.3"
+-
+-[[package]]
+-name = "typing-extensions"
+-version = "4.15.0"
+-description = "Backported and Experimental Type Hints for Python 3.9+"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
+-    {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+-]
+-
+-[[package]]
+-name = "urllib3"
+-version = "2.5.0"
+-description = "HTTP library with thread-safe connection pooling, file post, and more."
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+-]
+-
+-[package.extras]
+-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+-h2 = ["h2 (>=4,<5)"]
+-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+-zstd = ["zstandard (>=0.18.0)"]
+-
+-[[package]]
+-name = "uvicorn"
+-version = "0.35.0"
+-description = "The lightning-fast ASGI server."
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a"},
+-    {file = "uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01"},
+-]
+-
+-[package.dependencies]
+-click = ">=7.0"
+-h11 = ">=0.8"
+-
+-[package.extras]
+-standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+-
+-[[package]]
+-name = "watchfiles"
+-version = "1.1.0"
+-description = "Simple, modern and high performance file watching and code reload in python."
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "watchfiles-1.1.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:27f30e14aa1c1e91cb653f03a63445739919aef84c8d2517997a83155e7a2fcc"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3366f56c272232860ab45c77c3ca7b74ee819c8e1f6f35a7125556b198bbc6df"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8412eacef34cae2836d891836a7fff7b754d6bcac61f6c12ba5ca9bc7e427b68"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df670918eb7dd719642e05979fc84704af913d563fd17ed636f7c4783003fdcc"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d7642b9bc4827b5518ebdb3b82698ada8c14c7661ddec5fe719f3e56ccd13c97"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:199207b2d3eeaeb80ef4411875a6243d9ad8bc35b07fc42daa6b801cc39cc41c"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a479466da6db5c1e8754caee6c262cd373e6e6c363172d74394f4bff3d84d7b5"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:935f9edd022ec13e447e5723a7d14456c8af254544cefbc533f6dd276c9aa0d9"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8076a5769d6bdf5f673a19d51da05fc79e2bbf25e9fe755c47595785c06a8c72"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:86b1e28d4c37e89220e924305cd9f82866bb0ace666943a6e4196c5df4d58dcc"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-win32.whl", hash = "sha256:d1caf40c1c657b27858f9774d5c0e232089bca9cb8ee17ce7478c6e9264d2587"},
+-    {file = "watchfiles-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:a89c75a5b9bc329131115a409d0acc16e8da8dfd5867ba59f1dd66ae7ea8fa82"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c9649dfc57cc1f9835551deb17689e8d44666315f2e82d337b9f07bd76ae3aa2"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:406520216186b99374cdb58bc48e34bb74535adec160c8459894884c983a149c"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb45350fd1dc75cd68d3d72c47f5b513cb0578da716df5fba02fff31c69d5f2d"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:11ee4444250fcbeb47459a877e5e80ed994ce8e8d20283857fc128be1715dac7"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bda8136e6a80bdea23e5e74e09df0362744d24ffb8cd59c4a95a6ce3d142f79c"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b915daeb2d8c1f5cee4b970f2e2c988ce6514aace3c9296e58dd64dc9aa5d575"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed8fc66786de8d0376f9f913c09e963c66e90ced9aa11997f93bdb30f7c872a8"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe4371595edf78c41ef8ac8df20df3943e13defd0efcb732b2e393b5a8a7a71f"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b7c5f6fe273291f4d414d55b2c80d33c457b8a42677ad14b4b47ff025d0893e4"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7738027989881e70e3723c75921f1efa45225084228788fc59ea8c6d732eb30d"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-win32.whl", hash = "sha256:622d6b2c06be19f6e89b1d951485a232e3b59618def88dbeda575ed8f0d8dbf2"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:48aa25e5992b61debc908a61ab4d3f216b64f44fdaa71eb082d8b2de846b7d12"},
+-    {file = "watchfiles-1.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:00645eb79a3faa70d9cb15c8d4187bb72970b2470e938670240c7998dad9f13a"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9dc001c3e10de4725c749d4c2f2bdc6ae24de5a88a339c4bce32300a31ede179"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d9ba68ec283153dead62cbe81872d28e053745f12335d037de9cbd14bd1877f5"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:130fc497b8ee68dce163e4254d9b0356411d1490e868bd8790028bc46c5cc297"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50a51a90610d0845a5931a780d8e51d7bd7f309ebc25132ba975aca016b576a0"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc44678a72ac0910bac46fa6a0de6af9ba1355669b3dfaf1ce5f05ca7a74364e"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a543492513a93b001975ae283a51f4b67973662a375a403ae82f420d2c7205ee"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ac164e20d17cc285f2b94dc31c384bc3aa3dd5e7490473b3db043dd70fbccfd"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7590d5a455321e53857892ab8879dce62d1f4b04748769f5adf2e707afb9d4f"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:37d3d3f7defb13f62ece99e9be912afe9dd8a0077b7c45ee5a57c74811d581a4"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:7080c4bb3efd70a07b1cc2df99a7aa51d98685be56be6038c3169199d0a1c69f"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-win32.whl", hash = "sha256:cbcf8630ef4afb05dc30107bfa17f16c0896bb30ee48fc24bf64c1f970f3b1fd"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:cbd949bdd87567b0ad183d7676feb98136cde5bb9025403794a4c0db28ed3a47"},
+-    {file = "watchfiles-1.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:0a7d40b77f07be87c6faa93d0951a0fcd8cbca1ddff60a1b65d741bac6f3a9f6"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5007f860c7f1f8df471e4e04aaa8c43673429047d63205d1630880f7637bca30"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:20ecc8abbd957046f1fe9562757903f5eaf57c3bce70929fda6c7711bb58074a"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2f0498b7d2a3c072766dba3274fe22a183dbea1f99d188f1c6c72209a1063dc"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:239736577e848678e13b201bba14e89718f5c2133dfd6b1f7846fa1b58a8532b"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eff4b8d89f444f7e49136dc695599a591ff769300734446c0a86cba2eb2f9895"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12b0a02a91762c08f7264e2e79542f76870c3040bbc847fb67410ab81474932a"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:29e7bc2eee15cbb339c68445959108803dc14ee0c7b4eea556400131a8de462b"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9481174d3ed982e269c090f780122fb59cee6c3796f74efe74e70f7780ed94c"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:80f811146831c8c86ab17b640801c25dc0a88c630e855e2bef3568f30434d52b"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:60022527e71d1d1fda67a33150ee42869042bce3d0fcc9cc49be009a9cded3fb"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-win32.whl", hash = "sha256:32d6d4e583593cb8576e129879ea0991660b935177c0f93c6681359b3654bfa9"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:f21af781a4a6fbad54f03c598ab620e3a77032c5878f3d780448421a6e1818c7"},
+-    {file = "watchfiles-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:5366164391873ed76bfdf618818c82084c9db7fac82b64a20c44d335eec9ced5"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:17ab167cca6339c2b830b744eaf10803d2a5b6683be4d79d8475d88b4a8a4be1"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:328dbc9bff7205c215a7807da7c18dce37da7da718e798356212d22696404339"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7208ab6e009c627b7557ce55c465c98967e8caa8b11833531fdf95799372633"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a8f6f72974a19efead54195bc9bed4d850fc047bb7aa971268fd9a8387c89011"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d181ef50923c29cf0450c3cd47e2f0557b62218c50b2ab8ce2ecaa02bd97e670"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:adb4167043d3a78280d5d05ce0ba22055c266cf8655ce942f2fb881262ff3cdf"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5701dc474b041e2934a26d31d39f90fac8a3dee2322b39f7729867f932b1d4"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b067915e3c3936966a8607f6fe5487df0c9c4afb85226613b520890049deea20"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:9c733cda03b6d636b4219625a4acb5c6ffb10803338e437fb614fef9516825ef"},
+-    {file = "watchfiles-1.1.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:cc08ef8b90d78bfac66f0def80240b0197008e4852c9f285907377b2947ffdcb"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:9974d2f7dc561cce3bb88dfa8eb309dab64c729de85fba32e98d75cf24b66297"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c68e9f1fcb4d43798ad8814c4c1b61547b014b667216cb754e606bfade587018"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95ab1594377effac17110e1352989bdd7bdfca9ff0e5eeccd8c69c5389b826d0"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fba9b62da882c1be1280a7584ec4515d0a6006a94d6e5819730ec2eab60ffe12"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3434e401f3ce0ed6b42569128b3d1e3af773d7ec18751b918b89cd49c14eaafb"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fa257a4d0d21fcbca5b5fcba9dca5a78011cb93c0323fb8855c6d2dfbc76eb77"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fd1b3879a578a8ec2076c7961076df540b9af317123f84569f5a9ddee64ce92"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62cc7a30eeb0e20ecc5f4bd113cd69dcdb745a07c68c0370cea919f373f65d9e"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:891c69e027748b4a73847335d208e374ce54ca3c335907d381fde4e41661b13b"},
+-    {file = "watchfiles-1.1.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:12fe8eaffaf0faa7906895b4f8bb88264035b3f0243275e0bf24af0436b27259"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:bfe3c517c283e484843cb2e357dd57ba009cff351edf45fb455b5fbd1f45b15f"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9ccbf1f129480ed3044f540c0fdbc4ee556f7175e5ab40fe077ff6baf286d4e"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba0e3255b0396cac3cc7bbace76404dd72b5438bf0d8e7cefa2f79a7f3649caa"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4281cd9fce9fc0a9dbf0fc1217f39bf9cf2b4d315d9626ef1d4e87b84699e7e8"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d2404af8db1329f9a3c9b79ff63e0ae7131986446901582067d9304ae8aaf7f"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e78b6ed8165996013165eeabd875c5dfc19d41b54f94b40e9fff0eb3193e5e8e"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:249590eb75ccc117f488e2fabd1bfa33c580e24b96f00658ad88e38844a040bb"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d05686b5487cfa2e2c28ff1aa370ea3e6c5accfe6435944ddea1e10d93872147"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d0e10e6f8f6dc5762adee7dece33b722282e1f59aa6a55da5d493a97282fedd8"},
+-    {file = "watchfiles-1.1.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:af06c863f152005c7592df1d6a7009c836a247c9d8adb78fef8575a5a98699db"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:865c8e95713744cf5ae261f3067861e9da5f1370ba91fc536431e29b418676fa"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42f92befc848bb7a19658f21f3e7bae80d7d005d13891c62c2cd4d4d0abb3433"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa0cc8365ab29487eb4f9979fd41b22549853389e22d5de3f134a6796e1b05a4"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:90ebb429e933645f3da534c89b29b665e285048973b4d2b6946526888c3eb2c7"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c588c45da9b08ab3da81d08d7987dae6d2a3badd63acdb3e206a42dbfa7cb76f"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c55b0f9f68590115c25272b06e63f0824f03d4fc7d6deed43d8ad5660cabdbf"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd17a1e489f02ce9117b0de3c0b1fab1c3e2eedc82311b299ee6b6faf6c23a29"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da71945c9ace018d8634822f16cbc2a78323ef6c876b1d34bbf5d5222fd6a72e"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:51556d5004887045dba3acdd1fdf61dddea2be0a7e18048b5e853dcd37149b86"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04e4ed5d1cd3eae68c89bcc1a485a109f39f2fd8de05f705e98af6b5f1861f1f"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-win32.whl", hash = "sha256:c600e85f2ffd9f1035222b1a312aff85fd11ea39baff1d705b9b047aad2ce267"},
+-    {file = "watchfiles-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:3aba215958d88182e8d2acba0fdaf687745180974946609119953c0e112397dc"},
+-    {file = "watchfiles-1.1.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3a6fd40bbb50d24976eb275ccb55cd1951dfb63dbc27cae3066a6ca5f4beabd5"},
+-    {file = "watchfiles-1.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9f811079d2f9795b5d48b55a37aa7773680a5659afe34b54cc1d86590a51507d"},
+-    {file = "watchfiles-1.1.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a2726d7bfd9f76158c84c10a409b77a320426540df8c35be172444394b17f7ea"},
+-    {file = "watchfiles-1.1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df32d59cb9780f66d165a9a7a26f19df2c7d24e3bd58713108b41d0ff4f929c6"},
+-    {file = "watchfiles-1.1.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0ece16b563b17ab26eaa2d52230c9a7ae46cf01759621f4fbbca280e438267b3"},
+-    {file = "watchfiles-1.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:51b81e55d40c4b4aa8658427a3ee7ea847c591ae9e8b81ef94a90b668999353c"},
+-    {file = "watchfiles-1.1.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2bcdc54ea267fe72bfc7d83c041e4eb58d7d8dc6f578dfddb52f037ce62f432"},
+-    {file = "watchfiles-1.1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:923fec6e5461c42bd7e3fd5ec37492c6f3468be0499bc0707b4bbbc16ac21792"},
+-    {file = "watchfiles-1.1.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7b3443f4ec3ba5aa00b0e9fa90cf31d98321cbff8b925a7c7b84161619870bc9"},
+-    {file = "watchfiles-1.1.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7049e52167fc75fc3cc418fc13d39a8e520cbb60ca08b47f6cedb85e181d2f2a"},
+-    {file = "watchfiles-1.1.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54062ef956807ba806559b3c3d52105ae1827a0d4ab47b621b31132b6b7e2866"},
+-    {file = "watchfiles-1.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a7bd57a1bb02f9d5c398c0c1675384e7ab1dd39da0ca50b7f09af45fa435277"},
+-    {file = "watchfiles-1.1.0.tar.gz", hash = "sha256:693ed7ec72cbfcee399e92c895362b6e66d63dac6b91e2c11ae03d10d503e575"},
+-]
+-
+-[package.dependencies]
+-anyio = ">=3.0.0"
+-
+-[[package]]
+-name = "websockets"
+-version = "15.0.1"
+-description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+-optional = false
+-python-versions = ">=3.9"
+-groups = ["main"]
+-files = [
+-    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
+-    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
+-    {file = "websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a"},
+-    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e"},
+-    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf"},
+-    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb"},
+-    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d"},
+-    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9"},
+-    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c"},
+-    {file = "websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256"},
+-    {file = "websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41"},
+-    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431"},
+-    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57"},
+-    {file = "websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905"},
+-    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562"},
+-    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792"},
+-    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413"},
+-    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8"},
+-    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3"},
+-    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf"},
+-    {file = "websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85"},
+-    {file = "websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065"},
+-    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3"},
+-    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665"},
+-    {file = "websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2"},
+-    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215"},
+-    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5"},
+-    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65"},
+-    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe"},
+-    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4"},
+-    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597"},
+-    {file = "websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9"},
+-    {file = "websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7"},
+-    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931"},
+-    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675"},
+-    {file = "websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151"},
+-    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22"},
+-    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f"},
+-    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8"},
+-    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375"},
+-    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d"},
+-    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4"},
+-    {file = "websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa"},
+-    {file = "websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561"},
+-    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5"},
+-    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a"},
+-    {file = "websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b"},
+-    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770"},
+-    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb"},
+-    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054"},
+-    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee"},
+-    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed"},
+-    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880"},
+-    {file = "websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411"},
+-    {file = "websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4"},
+-    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3"},
+-    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1"},
+-    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475"},
+-    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9"},
+-    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04"},
+-    {file = "websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122"},
+-    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940"},
+-    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e"},
+-    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9"},
+-    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b"},
+-    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f"},
+-    {file = "websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123"},
+-    {file = "websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f"},
+-    {file = "websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee"},
+-]
+-
+-[metadata]
+-lock-version = "2.1"
+-python-versions = "^3.13"
+-content-hash = "431c6ea262aa9b219a6ef6590fea6b4cf6fecb7d7b84c627566fb1bf069f438d"
+diff --git a/docs/pyproject.toml b/docs/pyproject.toml
+index 780cb545..f9842b5c 100644
+--- a/docs/pyproject.toml
++++ b/docs/pyproject.toml
+@@ -1,21 +1,18 @@
+-[tool.poetry]
++[project]
+ name = "sphinx-docs"
+-description = "ScyllaDB C Sharp driver documentation"
++description = "ScyllaDB Documentation"
+ version = "0.1.0"
+-authors = ["ScyllaDB Documentation Contributors"]
+-package-mode = false
++requires-python = ">=3.11"
++dependencies = [
++    "pygments>=2.18.0",
++    "sphinx-scylladb-theme>=1.9.1",
++    "myst-parser>=5.0.0",
++    "sphinx-autobuild>=2025.4.8",
++    "sphinx>=9.0",
++    "sphinx-multiversion-scylla>=0.3.7",
++    "sphinx-sitemap>=2.9.0",
++    "redirects_cli>=0.1.3",
++]
+
+-[tool.poetry.dependencies]
+-python = "^3.13"
+-pygments = "^2.19.2"
+-sphinx-scylladb-theme = "^1.8.2"
+-myst-parser = "^4.0.1"
+-sphinx-autobuild = "^2025.0.0"
+-Sphinx = "^8.0.0"
+-sphinx-multiversion-scylla = "^0.3.2"
+-sphinx-sitemap = "^2.8.0"
+-redirects_cli ="^0.1.3"
+-
+-[build-system]
+-requires = ["poetry>=1.8.0"]
+-build-backend = "poetry.masonry.api"
++[tool.uv]
++package = false
+diff --git a/docs/source/api-docs/docfx.json b/docs/source/api-docs/docfx.json
+index 207fb99a..bb6d5fc5 100644
+--- a/docs/source/api-docs/docfx.json
++++ b/docs/source/api-docs/docfx.json
+@@ -8,7 +8,7 @@
+             "src/Extensions/Cassandra.AppMetrics/**.csproj",
+             "src/Extensions/Cassandra.OpenTelemetry/**.csproj"
+           ],
+-		  "src": "../../"
++          "src": "../../../"
+         }
+       ],
+       "dest": "api",
+@@ -31,18 +31,25 @@
+ 		"files": [ "index.md", "toc.yml" ]
+ 	  }
+     ],
++    "resource": [
++      {
++        "files": [ "logo.svg", "favicon.ico" ]
++      }
++    ],
+     "dest": "api-docs",
+     "globalMetadataFiles": [],
+     "fileMetadataFiles": [],
+     "template": [
+       "statictoc",
+-	  "datastax-template"
++      "template"
+     ],
+ 	"globalMetadata": {
+       "_appTitle": "ScyllaDB C# Driver for Scylla",
+       "_enableSearch": true,
+ 	  "_disableContribution": true,
+-	  "_appFooter": "© DataStax, All rights reserved."
++	  "_appFooter": "<p>ScyllaDB C# Driver is available under the <a href=\"https://www.apache.org/licenses/LICENSE-2.0.html\">Apache v2 License</a>. ScyllaDB C# Driver is a fork of <a href=\"https://github.com/datastax/csharp-driver\">DataStax C# Driver</a>. See Copyright <a href=\"https://csharp-driver.docs.scylladb.com/stable/#license\">here</a>.</p>",
++      "_appLogoPath": "logo.svg",
++      "_appFaviconPath": "favicon.ico"
+     },
+     "postProcessors": [],
+     "markdownEngineName": "markdig",
+diff --git a/docs/source/api-docs/logo.svg b/docs/source/api-docs/logo.svg
+new file mode 100644
+index 00000000..108f7daa
+--- /dev/null
++++ b/docs/source/api-docs/logo.svg
+@@ -0,0 +1 @@
++<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1200 300"><defs><style> .cls-1 { fill: #fff; } .cls-2 { fill: #57d1e5; } .cls-3 { fill: #3b2d55; } .cls-4 { fill: #4d9bb6; } .cls-5 { fill: #93e1ef; } </style></defs><g><g id="Layer_1"><g id="Layer_1-2" data-name="Layer_1"><g><g><path class="cls-1" d="M314.6,203c4.3,6.4,9.7,11.1,16.3,14.1,6.6,3,13.5,4.5,20.5,4.5s7.9-.6,12-1.8,7.8-3.1,11.2-5.5c3.4-2.5,6.1-5.5,8.2-9.1s3.2-7.8,3.2-12.5-2.1-11.8-6.4-15.4c-4.3-3.5-9.5-6.5-15.8-8.8-6.3-2.4-13.2-4.7-20.6-6.9-7.5-2.2-14.3-5.3-20.6-9.2-6.3-3.9-11.6-9.2-15.8-15.8-4.3-6.6-6.4-15.6-6.4-26.9s1.1-10.5,3.3-16.2c2.2-5.7,5.7-11,10.4-15.7,4.7-4.7,10.8-8.7,18.3-11.9,7.5-3.2,16.4-4.8,26.9-4.8s18.6,1.3,27.3,3.9c8.7,2.6,16.3,7.9,22.8,16l-19.2,17.4c-2.9-4.6-7.1-8.3-12.5-11.1-5.4-2.8-11.5-4.2-18.4-4.2s-12,.9-16.3,2.6-7.8,3.9-10.4,6.6-4.5,5.6-5.5,8.7c-1.1,3.1-1.6,6-1.6,8.6,0,7.4,2.1,13,6.4,16.9,4.3,3.9,9.5,7.1,15.8,9.6s13.2,4.7,20.6,6.6c7.5,2,14.3,4.7,20.6,8.2,6.3,3.5,11.6,8.3,15.8,14.2,4.3,6,6.4,14.2,6.4,24.7s-1.6,15.9-4.8,22.6c-3.2,6.7-7.5,12.4-12.9,16.9-5.4,4.6-11.8,8.1-19.2,10.6-7.4,2.5-15.2,3.7-23.6,3.7s-21.7-2-31.7-5.9-17.9-10-23.8-18.2l19.4-16.7v.2Z"></path><path class="cls-1" d="M519,153.9c-4.1-4.3-8.4-7.5-12.9-9.7s-9.9-3.3-16.1-3.3-11.3,1.1-15.8,3.3-8.3,5.2-11.3,9.1c-3,3.8-5.3,8.3-6.9,13.3s-2.3,10.2-2.3,15.6.9,10.5,2.7,15.4c1.8,4.8,4.3,9.1,7.6,12.7,3.3,3.6,7.2,6.4,11.8,8.5,4.6,2,9.7,3.1,15.5,3.1s11.5-1.1,16-3.3c4.4-2.2,8.5-5.4,12.3-9.7l15.7,15.7c-5.7,6.4-12.4,11-20,13.8-7.6,2.8-15.7,4.2-24.2,4.2s-17.2-1.5-24.7-4.4-13.9-7.1-19.3-12.4c-5.4-5.3-9.6-11.7-12.5-19.2-2.9-7.4-4.4-15.7-4.4-24.7s1.5-17.3,4.4-24.8,7.1-14,12.4-19.4,11.7-9.6,19.2-12.7c7.5-3,15.8-4.5,24.9-4.5s16.7,1.5,24.4,4.5c7.8,3,14.5,7.7,20.3,13.9l-16.7,15.2v-.2Z"></path><path class="cls-1" d="M543.8,123h25.5l34.5,90.9h.5l33.1-90.9h23.6l-55.3,141.5c-2,5.1-4,9.7-6.1,13.9-2.1,4.2-4.6,7.7-7.6,10.7-2.9,2.9-6.5,5.2-10.6,6.9-4.2,1.6-9.3,2.5-15.3,2.5s-6.6-.2-9.9-.6c-3.3-.4-6.6-1.3-9.7-2.6l2.7-20.1c4.4,1.8,8.8,2.7,13.2,2.7s6.3-.5,8.7-1.4,4.4-2.2,6.1-3.9c1.7-1.7,3.1-3.7,4.3-6,1.1-2.3,2.3-4.9,3.4-7.9l7.2-18.4-48.2-117.2h-.1Z"></path><path class="cls-1" d="M677.4,53.7h22.1v185.7h-22.1V53.7Z"></path><path class="cls-1" d="M723.5,53.7h22.1v185.7h-22.1V53.7Z"></path><path class="cls-1" d="M776.6,137.2c6.2-5.7,13.4-10,21.6-12.9,8.2-2.9,16.4-4.3,24.6-4.3s15.8,1.1,22,3.2c6.1,2.1,11.2,5,15.1,8.6,3.9,3.6,6.8,7.7,8.7,12.4s2.8,9.5,2.8,14.6v59.4c0,4.1,0,7.9.2,11.3.2,3.4.4,6.7.7,9.8h-19.7c-.5-5.9-.7-11.8-.7-17.7h-.5c-4.9,7.5-10.7,12.9-17.4,16s-14.5,4.7-23.3,4.7-10.6-.7-15.5-2.2-9.2-3.7-12.9-6.6c-3.7-2.9-6.6-6.6-8.7-10.9-2.1-4.3-3.2-9.4-3.2-15.1s1.7-13.8,5-18.9c3.4-5.1,7.9-9.2,13.8-12.4,5.8-3.2,12.6-5.5,20.4-6.9,7.8-1.4,16.1-2.1,24.9-2.1h16.2v-4.9c0-2.9-.6-5.9-1.7-8.8-1.1-2.9-2.9-5.6-5.2-8s-5.2-4.3-8.6-5.6c-3.4-1.4-7.5-2.1-12.3-2.1s-8,.4-11.2,1.2-6.1,1.8-8.7,3.1c-2.6,1.2-5,2.7-7.1,4.3s-4.2,3.2-6.1,4.7l-13.3-13.8h.1ZM839,183.4c-5.2,0-10.6.3-16.1.9-5.5.6-10.5,1.7-15,3.3s-8.2,3.9-11.1,6.9c-2.9,2.9-4.3,6.7-4.3,11.3,0,6.7,2.2,11.5,6.8,14.5,4.5,2.9,10.6,4.4,18.3,4.4s11.2-1,15.5-3.1c4.3-2,7.7-4.7,10.3-8s4.5-6.9,5.6-10.9,1.7-8,1.7-11.9v-7.4h-11.8,0Z"></path><path class="cls-1" d="M900.6,65.5h60.7c12.3,0,23,1.4,32.3,4.2,9.3,2.8,17.3,6.5,24.1,11.2,6.8,4.7,12.4,10,16.9,16.1s8.1,12.3,10.7,18.7,4.5,12.8,5.6,19.2,1.7,12.3,1.7,17.7c0,11.1-2.1,21.9-6.1,32.3-4.1,10.4-10.2,19.7-18.2,27.8s-18,14.6-29.8,19.5c-11.9,4.9-25.6,7.4-41.1,7.4h-56.7V65.5h0ZM924.2,217.3h29.7c10,0,19.4-1.4,28.4-4.1,8.9-2.7,16.7-6.8,23.5-12.2,6.7-5.4,12-12.2,16-20.3,3.9-8.1,5.9-17.6,5.9-28.4s-.9-12.1-2.7-19.5c-1.8-7.4-5.2-14.5-10.2-21.2s-11.9-12.4-20.8-17.1c-8.8-4.7-20.3-7-34.4-7h-35.4v129.7h0Z"></path><path class="cls-1" d="M1079.1,65.5h60.4c7.5,0,14.5.9,21,2.7,6.5,1.8,12,4.5,16.7,8s8.4,8,11.1,13.5,4.1,11.9,4.1,19.3-2.8,18.1-8.4,24.4c-5.6,6.3-12.8,10.9-21.6,13.9v.5c5.2.3,10.2,1.7,14.7,4.1,4.6,2.4,8.6,5.5,11.9,9.3,3.4,3.8,6,8.3,8,13.4,2,5.1,2.9,10.6,2.9,16.5s-1.6,14.8-4.8,20.8c-3.2,6-7.6,11-13.1,15.1-5.6,4.1-12,7.2-19.4,9.3s-15.3,3.2-23.8,3.2h-59.7V65.5h0ZM1102.7,137.7h32.2c4.4,0,8.6-.4,12.5-1.4,3.9-.9,7.4-2.4,10.3-4.5s5.3-4.8,7-8.1c1.7-3.3,2.6-7.3,2.6-12,0-6.9-2.2-12.9-6.6-17.9-4.4-5.1-11.4-7.6-20.9-7.6h-37.1v51.6h0ZM1102.7,218.8h34.6c3.6,0,7.6-.4,11.9-1.1,4.3-.7,8.4-2.2,12.2-4.4,3.8-2.2,7-5.2,9.6-9s3.9-8.8,3.9-15c0-10.3-3.4-18.1-10.1-23.2-6.7-5.2-15.8-7.7-27.3-7.7h-34.9v60.4h.1Z"></path></g><g><g><path class="cls-2" d="M112.5,3C46.3,3,0,44.2,0,103.2s10,70.1,18.4,112.4c6,30.5,11.3,55.1,11.4,55.6,1.7,7.5,8.9,12.3,16.5,11.1l1.6-.2-1.1-1.1c-2.1-2.2-3.7-4.8-4.6-7.6-.5-1.6-.7-3-.9-4.3,0-.6-.2-1.2-.3-1.8l-2.9-17.8c-1.3-8.1-2.5-16.1-3.7-23.8,0-.5.3-1,.8-1.1.5,0,1,.3,1.1.7,1.6,7.6,3.2,15.6,4.8,23.6l3.4,17.8c0,.6.2,1.1.3,1.7.3,1.4.5,2.9.9,3.9.9,3,2.9,5.7,5.6,7.6.3.2.6.4.9.6,1.5.9,3.2,1.5,4.9,1.8,1.8.3,3.6.2,5.3-.1,1.9-.4,3.8-1.2,5.4-2.4l.6-.5-.5-.7c-1.3-1.9-2.2-3.9-2.8-6.1-.4-1.7-.5-3.1-.6-4.5,0-.6,0-1.2-.2-1.7l-1.8-17.9c-.8-8.2-1.5-16.2-2.1-23.9,0-.3,0-.5.2-.7s.4-.3.6-.3c.5,0,.9.3,1,.8,1.1,7.6,2.2,15.6,3.3,23.8l2.3,17.9c0,.5,0,1.1.2,1.7.2,1.5.4,2.9.6,4,.3,1.3.9,2.6,1.6,3.8,1,1.7,2.4,3.2,4.1,4.4h0c0,.2.2.2.3.3,2.9,1.9,6.6,2.8,10.1,2.2,3.5-.5,6.7-2.4,9-5.1.6-.7,1.1-1.4,1.5-2.2l.2-.3v-.3c-.4-.8-.6-1.6-.8-2.5-.3-1.2-.4-2.8-.4-4.7v-8.9c-.3-11.2-.4-22.8-.4-35.4s.4-.9.9-.9.9.4.9.9c.8,12.6,1.3,24.2,1.8,35.4l.4,8.8c0,1.6,0,2.8.4,4.1.3,1,.7,2.4,1.4,3.6,0,0,0,.1.2.3,2.5,4.5,7.3,7.4,12.4,7.4h.2c5,.1,10.1-2.8,12.6-7.4,0,0,0-.1,0-.2.6-1,1-2.2,1.4-3.7.3-1.2.3-2.4.4-3.9l.4-9c.4-10.6,1-22.1,1.8-35.4,0-.5.5-.9,1-.9s.9.4.9.9c0,13.2,0,24.8-.3,35.4v8.9c-.2,1.2-.2,3.1-.5,4.7-.2.9-.4,1.7-.7,2.5v.3c-.1,0,0,.3,0,.3.4.8.9,1.5,1.5,2.2,2.3,2.8,5.5,4.6,9,5.1s7.2-.3,10.1-2.2c0,0,.2-.1.3-.2h.1c1.6-1.2,3-2.8,4.1-4.5.7-1.2,1.2-2.5,1.6-3.8.3-1.1.5-2.6.6-4.1,0-.5.1-1.1.2-1.6l2.3-17.9c1.1-8.1,2.2-16.2,3.3-23.8,0-.3.2-.5.4-.6.2-.2.5-.2.7-.2.5,0,.8.5.8,1-.6,7.7-1.3,15.7-2.1,23.9l-1.8,17.9c0,.6-.1,1.1-.2,1.7-.1,1.4-.3,2.8-.6,4.5-.5,2.2-1.4,4.2-2.7,6.1l-.5.7.6.5c1.7,1.2,3.5,2,5.4,2.4,1.7.4,3.5.4,5.3.1s3.4-.9,5-1.8c.3-.2.6-.4.9-.6,2.7-1.8,4.7-4.5,5.6-7.6.3-1.1.6-2.6.9-4,.1-.6.2-1.1.3-1.7l3.4-17.8c1.6-8.1,3.2-16,4.8-23.6.1-.5.6-.8,1.1-.7s.8.6.7,1.1c-1.1,7.7-2.4,15.7-3.7,23.8l-2.9,17.8c-.1.6-.2,1.2-.3,1.8-.2,1.3-.4,2.7-.9,4.3-.8,2.8-2.4,5.4-4.5,7.6l-1,1,1.4.3h0c.8.1,1.6.2,2.4.2,6.6,0,12.6-4.6,14.1-11.3.1-.6,5.5-26.1,11.7-57.3,8.3-42.1,18-94.6,18-110.7,0-59-46.3-100.2-112.5-100.2h0Z"></path><path class="cls-3" d="M206.7,215.5c-6.2,31.6-11.4,55.3-11.5,55.7-1.4,6.4-7.5,11-14,11s-1.5,0-2.3-.2l-.8-.2.5-.6c2.2-2.2,3.8-4.9,4.6-7.7.5-1.6.7-3,.9-4.4v-.2c.1-.5.2-1,.3-1.6l2.9-17.8c1.3-8.1,2.5-16.1,3.7-23.8.1-.7-.4-1.3-1-1.5-.4,0-.7,0-1,.2s-.5.5-.6.8c-1.6,7.5-3.2,15.5-4.8,23.6l-3.4,17.7c0,.4-.2.8-.2,1.2v.5c-.4,1.4-.6,2.8-1,3.9-.9,3-2.8,5.6-5.5,7.4-.3.2-.6.4-.9.6-1.5.9-3.1,1.4-4.8,1.7-1.7.3-3.4.2-5.1-.1-1.9-.4-3.7-1.2-5.3-2.4l-.3-.2.2-.3c1.3-1.9,2.3-4,2.8-6.2.4-1.7.5-3.1.6-4.5,0-.6.1-1.1.2-1.7l1.8-17.9c.8-8.3,1.5-16.4,2.1-23.9,0-.7-.4-1.3-1.1-1.4-.4,0-.7,0-1,.3-.3.2-.5.5-.5.9-1.1,7.6-2.2,15.6-3.3,23.8l-2.3,17.9c0,.5-.1,1.1-.2,1.7-.2,1.5-.4,2.9-.6,4-.3,1.3-.8,2.5-1.5,3.7-1,1.7-2.4,3.2-4,4.3h-.1c0,.2-.2.2-.3.3-2.8,1.9-6.4,2.7-9.8,2.2-3.4-.5-6.6-2.3-8.7-5-.5-.6-1-1.3-1.4-2.1v-.4c.3-.8.5-1.6.7-2.5.4-1.7.4-3.6.4-4.8v-8.9c.3-10.5.4-22,.4-35.4s-.6-1.3-1.3-1.3-1.4.5-1.4,1.2c-.8,13.1-1.3,24.7-1.8,35.4l-.4,9c0,1.5,0,2.6-.4,3.8-.3,1.4-.8,2.6-1.3,3.6v.2c-2.5,4.3-7.3,7.2-12.2,7.2s-.2,0-.3,0h-.2c-4.9,0-9.6-2.8-12-7.2,0-.1,0-.2-.2-.2-.7-1.2-1.1-2.5-1.3-3.5-.3-1.3-.3-2.4-.4-4l-.4-8.8c-.4-11.1-1-22.7-1.8-35.4,0-.7-.6-1.2-1.3-1.2s-1.3.6-1.3,1.3c0,12.7,0,24.2.3,35.4v8.9c0,2,.3,3.5.6,4.8.2.9.4,1.7.7,2.5v.4c-.4.7-.9,1.5-1.5,2.1-2.2,2.7-5.4,4.5-8.7,5-3.4.5-7-.3-9.8-2.2,0,0,0-.1-.3-.2h0c-1.6-1.2-3-2.7-3.9-4.4-.7-1.2-1.2-2.4-1.5-3.7-.3-1.1-.4-2.5-.6-4,0-.5,0-1.1-.2-1.6l-2.3-17.9c-1.1-8.3-2.2-16.3-3.3-23.8,0-.7-.7-1.2-1.4-1.1-.4,0-.7.2-.9.5s-.3.6-.3,1c.6,7.7,1.3,15.8,2.1,23.9l1.8,17.9c0,.6,0,1.1.2,1.7,0,1.4.3,2.8.6,4.5.5,2.2,1.5,4.3,2.8,6.2l.2.3-.3.3c-1.6,1.2-3.4,2-5.3,2.4-1.7.4-3.4.4-5.2.1-1.7-.3-3.3-.9-4.8-1.7-.3-.2-.6-.4-.9-.6-2.6-1.8-4.6-4.4-5.5-7.4-.3-1-.6-2.4-.8-3.8v-.2c0-.5-.2-1.1-.4-1.6l-3.4-17.8c-1.6-8.1-3.2-16-4.8-23.6,0-.7-.8-1.1-1.5-1s-1.2.8-1.1,1.5c1.1,7.7,2.4,15.8,3.7,23.8l2.9,17.8c0,.5.2,1.1.3,1.6v.2c.2,1.3.5,2.7.9,4.4.8,2.8,2.5,5.5,4.6,7.7l.6.6h-.8c-7.4,1.4-14.4-3.4-16.1-10.7-.6-2.6-6-26.3-11.8-55.6,0,0,8.4,56.3,8.4,56.5.1.5.2,1,.4,1.5l.2.5c.1.3.2.6.4.9,0,.2.2.4.3.6.1.2.2.5.4.7h0c.1.3.2.5.3.7,0,.1.1.2.2.3h0c.4.7.8,1.3,1.2,1.8h0c.2.4.5.6.8,1h.1c.3.4.5.7.8,1h0c3.3,3,7.4,4.7,11.8,4.7s1.9,0,2.9-.2l6.5-1c1.1.4,2.2.7,3.4.9,2.1.3,4.3.3,6.4-.2,2.3-.5,4.6-1.5,6.6-3l1.6-1.1c.5.4,1,.8,1.5,1.2h0c0,.2.3.3.4.4,3.5,2.3,8,3.3,12.2,2.7,4.2-.6,8.2-2.9,10.9-6.2.5-.6.9-1.2,1.4-1.9,3.1,5,8.8,8.2,14.6,8.2h.5c5.8,0,11.5-3.2,14.6-8.2.4.7.9,1.3,1.4,1.9,2.7,3.3,6.7,5.6,10.9,6.2.8.1,1.7.2,2.5.2,3.4,0,6.9-1,9.7-2.9.1,0,.3-.2.4-.3h0c.5-.4,1-.8,1.5-1.3l1.6,1.1c2,1.5,4.3,2.5,6.6,2.9,2.1.4,4.3.5,6.4.1,1.5-.2,2.9-.6,4.2-1.2l5.5,1.3h.2c.9.2,1.9.3,2.8.3,8.1,0,15.3-5.8,17-13.7,0-.3,8.5-56.4,8.5-56.4l.3-.4Z"></path></g><path class="cls-5" d="M32.2,30.3C11.9,48,0,73.3,0,103.2s29.2,166.6,29.5,168c.7,3,2.8,5.3,4.9,7.2C27.1,243.5,3.5,130.4,3.5,104.1S14,49.3,32.2,30.3"></path><g><path class="cls-4" d="M82.4,46.2c-27,0-48.9,22-48.9,48.9s22,48.9,48.9,48.9,48.9-22,48.9-48.9-22-48.9-48.9-48.9"></path><path class="cls-1" d="M28.6,91.2c0,27,22,48.9,48.9,48.9s48.9-22,48.9-48.9-22-48.9-48.9-48.9-48.9,22-48.9,48.9"></path><path class="cls-3" d="M110.9,92c-.7,20.6-15.4,31.4-24.8,29.2-7.8-1.9-8.8-19.3-3.9-23.9,3.2-3,9.6-3.8,9.7-6,0-2.2-6.3-3.4-9.3-6.7-4.6-4.9-2.4-22.2,5.6-23.5,9.5-1.6,23.4,10.3,22.7,30.9"></path><g><path class="cls-4" d="M47.4,160.3c29.8,4.3,61-3.1,85.5-20.4,3.4-2.3,6.9,2.7,3.6,5.1-13,8.9-27.7,15.3-43.1,18.8-15.3,3.5-31.3,4-46.8,1.6-1.4-.2-2.4-1.6-2.2-3s1.5-2.4,2.9-2.2"></path><path class="cls-4" d="M136.4,148.1c-.8-4-4.4-7-8.4-7.2-4.1-.3-3.9-6.4.3-6.3,3.4.4,6.5,2.2,8.7,4.7,1.9,1.8,6,9.9,1.6,10.5-1.1,0-2-.6-2.2-1.7"></path></g><path class="cls-3" d="M46.4,158.1c29.8,4.3,61-3.1,85.5-20.4,3.4-2.3,6.9,2.7,3.6,5.1-13,8.9-27.7,15.3-43.1,18.8-15.3,3.5-31.3,4-46.8,1.6-1.4-.2-2.4-1.6-2.2-3s1.5-2.4,2.9-2.2"></path><path class="cls-3" d="M135.4,145.9c-.8-4-4.4-7-8.4-7.2-4.1-.3-3.9-6.4.3-6.3,3.4.4,6.5,2.2,8.7,4.7,1.9,1.8,6,9.9,1.6,10.5-1.1,0-2-.6-2.2-1.7"></path></g></g></g></g></g></g></svg>
+\ No newline at end of file
+diff --git a/docs/source/api-docs/template/styles/main.css b/docs/source/api-docs/template/styles/main.css
+new file mode 100644
+index 00000000..0eb9d32c
+--- /dev/null
++++ b/docs/source/api-docs/template/styles/main.css
+@@ -0,0 +1,37 @@
++/* Text */
++button, a, .toc .nav > li.active > a {
++  color: #3c4fe0;
++}
++
++button:hover, a:hover, .toc .nav > li.active > a:hover {
++  color: #3c4fe0;
++}
++
++.navbar-brand {
++  display: block;
++}
++
++/* Navbar */
++.navbar-inverse {
++  background-color: #0f1040;
++}
++
++.navbar-inverse .navbar-nav>li>a {
++  color: #fff;
++}
++
++.nav>li {
++  word-break: break-word;
++}
++
++/* Logo */
++.navbar-brand {
++  height: 30px;
++  margin-top: 10px;
++}
++
++#logo.svg {
++  max-height: 30px;
++  height: 30px;
++  width: auto;
++}
+diff --git a/docs/source/api-reference.md b/docs/source/api-reference.md
+new file mode 100644
+index 00000000..15fc1299
+--- /dev/null
++++ b/docs/source/api-reference.md
+@@ -0,0 +1,6 @@
++# API Reference
++
++The ScyllaDB C# driver is a fork of DataStax C# driver, which includes some
++non-breaking changes for ScyllaDB optimization.
++
++Browse the <a href="/api-docs/" target="_blank">API reference</a> for the ScyllaDB C# driver.
+diff --git a/docs/source/conf.py b/docs/source/conf.py
+index 20fe8b3d..5a91cd7c 100644
+--- a/docs/source/conf.py
++++ b/docs/source/conf.py
+@@ -3,8 +3,10 @@ import os
+ import sys
+ import warnings
+ from datetime import date
++from pathlib import Path
+
+ from sphinx_scylladb_theme.utils import multiversion_regex_builder
++from redirects_cli import cli as redirects_cli
+
+ # -- Global variables
+
+@@ -50,7 +52,7 @@ author = "ScyllaDB Project Contributors"
+
+ # List of patterns, relative to source directory, that match files and
+ # directories to ignore when looking for source files.
+-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**/_partials", "api-docs"]
++exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**/_partials", "api-docs", ".venv"]
+
+ # The name of the Pygments (syntax highlighting) style to use.
+ pygments_style = "sphinx"
+@@ -126,9 +128,29 @@ htmlhelp_basename = "ScyllaDocumentationdoc"
+ # URL which points to the root of the HTML documentation.
+ html_baseurl = "https://csharp-driver.docs.scylladb.com"
+
+-# Dictionary of values to pass into the template engine’s context for all pages
++# Dictionary of values to pass into the template engine's context for all pages
+ html_context = {"html_baseurl": html_baseurl}
+
++# -- Redirects Configuration ----------------------------------------
++
++
++def redirect_api_page_to_docfx(app, exception):
++    """Create redirects from api-reference pages to the DocFX API documentation"""
++    api_reference_path = 'api-reference'
++    version_name = os.getenv("SPHINX_MULTIVERSION_NAME", "")
++    version_name = "/" + version_name if version_name else ""
++    redirect_to = version_name + '/api-docs/index.html'
++
++    # Create redirect at api-reference.html
++    out_file_1 = Path(app.outdir) / f'{api_reference_path}.html'
++    redirects_cli.create(redirect_to=redirect_to, out_file=str(out_file_1))
++
++    # Create redirect at api-reference/index.html
++    out_file_2 = Path(app.outdir) / api_reference_path / 'index.html'
++    out_file_2.parent.mkdir(parents=True, exist_ok=True)
++    redirects_cli.create(redirect_to=redirect_to, out_file=str(out_file_2))
++
++
+ # -- Initialize Sphinx ----------------------------------------------
+
+
+@@ -138,3 +160,4 @@ def setup(sphinx):
+         category=UserWarning,
+         message=r".*Container node skipped.*",
+     )
++    sphinx.connect('build-finished', redirect_api_page_to_docfx)
+diff --git a/docs/uv.lock b/docs/uv.lock
+new file mode 100644
+index 00000000..05d819d2
+--- /dev/null
++++ b/docs/uv.lock
+@@ -0,0 +1,1014 @@
++version = 1
++revision = 3
++requires-python = ">=3.11"
++resolution-markers = [
++    "python_full_version >= '3.12'",
++    "python_full_version < '3.12'",
++]
++
++[[package]]
++name = "alabaster"
++version = "1.0.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
++]
++
++[[package]]
++name = "annotated-doc"
++version = "0.0.4"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
++]
++
++[[package]]
++name = "anyio"
++version = "4.12.1"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "idna" },
++    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
++]
++
++[[package]]
++name = "babel"
++version = "2.18.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
++]
++
++[[package]]
++name = "beartype"
++version = "0.22.9"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
++]
++
++[[package]]
++name = "beautifulsoup4"
++version = "4.14.3"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "soupsieve" },
++    { name = "typing-extensions" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
++]
++
++[[package]]
++name = "certifi"
++version = "2026.2.25"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
++]
++
++[[package]]
++name = "charset-normalizer"
++version = "3.4.5"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/8f/9e/bcec3b22c64ecec47d39bf5167c2613efd41898c019dccd4183f6aa5d6a7/charset_normalizer-3.4.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:610f72c0ee565dfb8ae1241b666119582fdbfe7c0975c175be719f940e110694", size = 279531, upload-time = "2026-03-06T06:00:52.252Z" },
++    { url = "https://files.pythonhosted.org/packages/58/12/81fd25f7e7078ab5d1eedbb0fac44be4904ae3370a3bf4533c8f2d159acd/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60d68e820af339df4ae8358c7a2e7596badeb61e544438e489035f9fbf3246a5", size = 188006, upload-time = "2026-03-06T06:00:53.8Z" },
++    { url = "https://files.pythonhosted.org/packages/ae/6e/f2d30e8c27c1b0736a6520311982cf5286cfc7f6cac77d7bc1325e3a23f2/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b473fc8dca1c3ad8559985794815f06ca3fc71942c969129070f2c3cdf7281", size = 205085, upload-time = "2026-03-06T06:00:55.311Z" },
++    { url = "https://files.pythonhosted.org/packages/d0/90/d12cefcb53b5931e2cf792a33718d7126efb116a320eaa0742c7059a95e4/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d4eb8ac7469b2a5d64b5b8c04f84d8bf3ad340f4514b98523805cbf46e3b3923", size = 200545, upload-time = "2026-03-06T06:00:56.532Z" },
++    { url = "https://files.pythonhosted.org/packages/03/f4/44d3b830a20e89ff82a3134912d9a1cf6084d64f3b95dcad40f74449a654/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bcb3227c3d9aaf73eaaab1db7ccd80a8995c509ee9941e2aae060ca6e4e5d81", size = 193863, upload-time = "2026-03-06T06:00:57.823Z" },
++    { url = "https://files.pythonhosted.org/packages/25/4b/f212119c18a6320a9d4a730d1b4057875cdeabf21b3614f76549042ef8a8/charset_normalizer-3.4.5-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:75ee9c1cce2911581a70a3c0919d8bccf5b1cbc9b0e5171400ec736b4b569497", size = 181827, upload-time = "2026-03-06T06:00:59.323Z" },
++    { url = "https://files.pythonhosted.org/packages/74/00/b26158e48b425a202a92965f8069e8a63d9af1481dfa206825d7f74d2a3c/charset_normalizer-3.4.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d1401945cb77787dbd3af2446ff2d75912327c4c3a1526ab7955ecf8600687c", size = 191085, upload-time = "2026-03-06T06:01:00.546Z" },
++    { url = "https://files.pythonhosted.org/packages/c4/c2/1c1737bf6fd40335fe53d28fe49afd99ee4143cc57a845e99635ce0b9b6d/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a45e504f5e1be0bd385935a8e1507c442349ca36f511a47057a71c9d1d6ea9e", size = 190688, upload-time = "2026-03-06T06:01:02.479Z" },
++    { url = "https://files.pythonhosted.org/packages/5a/3d/abb5c22dc2ef493cd56522f811246a63c5427c08f3e3e50ab663de27fcf4/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e09f671a54ce70b79a1fc1dc6da3072b7ef7251fadb894ed92d9aa8218465a5f", size = 183077, upload-time = "2026-03-06T06:01:04.231Z" },
++    { url = "https://files.pythonhosted.org/packages/44/33/5298ad4d419a58e25b3508e87f2758d1442ff00c2471f8e0403dab8edad5/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d01de5e768328646e6a3fa9e562706f8f6641708c115c62588aef2b941a4f88e", size = 206706, upload-time = "2026-03-06T06:01:05.773Z" },
++    { url = "https://files.pythonhosted.org/packages/7b/17/51e7895ac0f87c3b91d276a449ef09f5532a7529818f59646d7a55089432/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:131716d6786ad5e3dc542f5cc6f397ba3339dc0fb87f87ac30e550e8987756af", size = 191665, upload-time = "2026-03-06T06:01:07.473Z" },
++    { url = "https://files.pythonhosted.org/packages/90/8f/cce9adf1883e98906dbae380d769b4852bb0fa0004bc7d7a2243418d3ea8/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a374cc0b88aa710e8865dc1bd6edb3743c59f27830f0293ab101e4cf3ce9f85", size = 201950, upload-time = "2026-03-06T06:01:08.973Z" },
++    { url = "https://files.pythonhosted.org/packages/08/ca/bce99cd5c397a52919e2769d126723f27a4c037130374c051c00470bcd38/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d31f0d1671e1534e395f9eb84a68e0fb670e1edb1fe819a9d7f564ae3bc4e53f", size = 195830, upload-time = "2026-03-06T06:01:10.155Z" },
++    { url = "https://files.pythonhosted.org/packages/87/4f/2e3d023a06911f1281f97b8f036edc9872167036ca6f55cc874a0be6c12c/charset_normalizer-3.4.5-cp311-cp311-win32.whl", hash = "sha256:cace89841c0599d736d3d74a27bc5821288bb47c5441923277afc6059d7fbcb4", size = 132029, upload-time = "2026-03-06T06:01:11.706Z" },
++    { url = "https://files.pythonhosted.org/packages/fe/1f/a853b73d386521fd44b7f67ded6b17b7b2367067d9106a5c4b44f9a34274/charset_normalizer-3.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:f8102ae93c0bc863b1d41ea0f4499c20a83229f52ed870850892df555187154a", size = 142404, upload-time = "2026-03-06T06:01:12.865Z" },
++    { url = "https://files.pythonhosted.org/packages/b4/10/dba36f76b71c38e9d391abe0fd8a5b818790e053c431adecfc98c35cd2a9/charset_normalizer-3.4.5-cp311-cp311-win_arm64.whl", hash = "sha256:ed98364e1c262cf5f9363c3eca8c2df37024f52a8fa1180a3610014f26eac51c", size = 132796, upload-time = "2026-03-06T06:01:14.106Z" },
++    { url = "https://files.pythonhosted.org/packages/9c/b6/9ee9c1a608916ca5feae81a344dffbaa53b26b90be58cc2159e3332d44ec/charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed97c282ee4f994ef814042423a529df9497e3c666dca19be1d4cd1129dc7ade", size = 280976, upload-time = "2026-03-06T06:01:15.276Z" },
++    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54", size = 189356, upload-time = "2026-03-06T06:01:16.511Z" },
++    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467", size = 206369, upload-time = "2026-03-06T06:01:17.853Z" },
++    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60", size = 203285, upload-time = "2026-03-06T06:01:19.473Z" },
++    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d", size = 196274, upload-time = "2026-03-06T06:01:20.728Z" },
++    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e", size = 184715, upload-time = "2026-03-06T06:01:22.194Z" },
++    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f", size = 193426, upload-time = "2026-03-06T06:01:23.795Z" },
++    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc", size = 191780, upload-time = "2026-03-06T06:01:25.053Z" },
++    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95", size = 185805, upload-time = "2026-03-06T06:01:26.294Z" },
++    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a", size = 208342, upload-time = "2026-03-06T06:01:27.55Z" },
++    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac", size = 193661, upload-time = "2026-03-06T06:01:29.051Z" },
++    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1", size = 204819, upload-time = "2026-03-06T06:01:30.298Z" },
++    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98", size = 198080, upload-time = "2026-03-06T06:01:31.478Z" },
++    { url = "https://files.pythonhosted.org/packages/56/5a/b8b5a23134978ee9885cee2d6995f4c27cc41f9baded0a9685eabc5338f0/charset_normalizer-3.4.5-cp312-cp312-win32.whl", hash = "sha256:1827734a5b308b65ac54e86a618de66f935a4f63a8a462ff1e19a6788d6c2262", size = 132630, upload-time = "2026-03-06T06:01:33.056Z" },
++    { url = "https://files.pythonhosted.org/packages/70/53/e44a4c07e8904500aec95865dc3f6464dc3586a039ef0df606eb3ac38e35/charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:728c6a963dfab66ef865f49286e45239384249672cd598576765acc2a640a636", size = 142856, upload-time = "2026-03-06T06:01:34.489Z" },
++    { url = "https://files.pythonhosted.org/packages/ea/aa/c5628f7cad591b1cf45790b7a61483c3e36cf41349c98af7813c483fd6e8/charset_normalizer-3.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:75dfd1afe0b1647449e852f4fb428195a7ed0588947218f7ba929f6538487f02", size = 132982, upload-time = "2026-03-06T06:01:35.641Z" },
++    { url = "https://files.pythonhosted.org/packages/f5/48/9f34ec4bb24aa3fdba1890c1bddb97c8a4be1bd84ef5c42ac2352563ad05/charset_normalizer-3.4.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac59c15e3f1465f722607800c68713f9fbc2f672b9eb649fe831da4019ae9b23", size = 280788, upload-time = "2026-03-06T06:01:37.126Z" },
++    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8", size = 188890, upload-time = "2026-03-06T06:01:38.73Z" },
++    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d", size = 206136, upload-time = "2026-03-06T06:01:40.016Z" },
++    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce", size = 202551, upload-time = "2026-03-06T06:01:41.522Z" },
++    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819", size = 195572, upload-time = "2026-03-06T06:01:43.208Z" },
++    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d", size = 184438, upload-time = "2026-03-06T06:01:44.755Z" },
++    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763", size = 193035, upload-time = "2026-03-06T06:01:46.051Z" },
++    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9", size = 191340, upload-time = "2026-03-06T06:01:47.547Z" },
++    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c", size = 185464, upload-time = "2026-03-06T06:01:48.764Z" },
++    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67", size = 208014, upload-time = "2026-03-06T06:01:50.371Z" },
++    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3", size = 193297, upload-time = "2026-03-06T06:01:51.933Z" },
++    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf", size = 204321, upload-time = "2026-03-06T06:01:53.887Z" },
++    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6", size = 197509, upload-time = "2026-03-06T06:01:56.439Z" },
++    { url = "https://files.pythonhosted.org/packages/fd/a5/c7d9dd1503ffc08950b3260f5d39ec2366dd08254f0900ecbcf3a6197c7c/charset_normalizer-3.4.5-cp313-cp313-win32.whl", hash = "sha256:f1d725b754e967e648046f00c4facc42d414840f5ccc670c5670f59f83693e4f", size = 132284, upload-time = "2026-03-06T06:01:57.812Z" },
++    { url = "https://files.pythonhosted.org/packages/b9/0f/57072b253af40c8aa6636e6de7d75985624c1eb392815b2f934199340a89/charset_normalizer-3.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:e37bd100d2c5d3ba35db9c7c5ba5a9228cbcffe5c4778dc824b164e5257813d7", size = 142630, upload-time = "2026-03-06T06:01:59.062Z" },
++    { url = "https://files.pythonhosted.org/packages/31/41/1c4b7cc9f13bd9d369ce3bc993e13d374ce25fa38a2663644283ecf422c1/charset_normalizer-3.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:93b3b2cc5cf1b8743660ce77a4f45f3f6d1172068207c1defc779a36eea6bb36", size = 133254, upload-time = "2026-03-06T06:02:00.281Z" },
++    { url = "https://files.pythonhosted.org/packages/43/be/0f0fd9bb4a7fa4fb5067fb7d9ac693d4e928d306f80a0d02bde43a7c4aee/charset_normalizer-3.4.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8197abe5ca1ffb7d91e78360f915eef5addff270f8a71c1fc5be24a56f3e4873", size = 280232, upload-time = "2026-03-06T06:02:01.508Z" },
++    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f", size = 189688, upload-time = "2026-03-06T06:02:02.857Z" },
++    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4", size = 206833, upload-time = "2026-03-06T06:02:05.127Z" },
++    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee", size = 202879, upload-time = "2026-03-06T06:02:06.446Z" },
++    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66", size = 195764, upload-time = "2026-03-06T06:02:08.763Z" },
++    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362", size = 183728, upload-time = "2026-03-06T06:02:10.137Z" },
++    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7", size = 192937, upload-time = "2026-03-06T06:02:11.663Z" },
++    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d", size = 192040, upload-time = "2026-03-06T06:02:13.489Z" },
++    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6", size = 184107, upload-time = "2026-03-06T06:02:14.83Z" },
++    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39", size = 208310, upload-time = "2026-03-06T06:02:16.165Z" },
++    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6", size = 192918, upload-time = "2026-03-06T06:02:18.144Z" },
++    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94", size = 204615, upload-time = "2026-03-06T06:02:19.821Z" },
++    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e", size = 197784, upload-time = "2026-03-06T06:02:21.86Z" },
++    { url = "https://files.pythonhosted.org/packages/c7/5e/1aab5cb737039b9c59e63627dc8bbc0d02562a14f831cc450e5f91d84ce1/charset_normalizer-3.4.5-cp314-cp314-win32.whl", hash = "sha256:ee57b926940ba00bca7ba7041e665cc956e55ef482f851b9b65acb20d867e7a2", size = 133009, upload-time = "2026-03-06T06:02:23.289Z" },
++    { url = "https://files.pythonhosted.org/packages/40/65/e7c6c77d7aaa4c0d7974f2e403e17f0ed2cb0fc135f77d686b916bf1eead/charset_normalizer-3.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:4481e6da1830c8a1cc0b746b47f603b653dadb690bcd851d039ffaefe70533aa", size = 143511, upload-time = "2026-03-06T06:02:26.195Z" },
++    { url = "https://files.pythonhosted.org/packages/ba/91/52b0841c71f152f563b8e072896c14e3d83b195c188b338d3cc2e582d1d4/charset_normalizer-3.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:97ab7787092eb9b50fb47fa04f24c75b768a606af1bcba1957f07f128a7219e4", size = 133775, upload-time = "2026-03-06T06:02:27.473Z" },
++    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
++]
++
++[[package]]
++name = "click"
++version = "8.3.1"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "colorama", marker = "sys_platform == 'win32'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
++]
++
++[[package]]
++name = "colorama"
++version = "0.4.6"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
++]
++
++[[package]]
++name = "docutils"
++version = "0.22.4"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
++]
++
++[[package]]
++name = "h11"
++version = "0.16.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
++]
++
++[[package]]
++name = "idna"
++version = "3.11"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
++]
++
++[[package]]
++name = "imagesize"
++version = "2.0.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
++]
++
++[[package]]
++name = "jinja2"
++version = "3.1.6"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "markupsafe" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
++]
++
++[[package]]
++name = "markdown-it-py"
++version = "4.0.0"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "mdurl" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
++]
++
++[[package]]
++name = "markupsafe"
++version = "3.0.3"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
++    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
++    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
++    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
++    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
++    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
++    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
++    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
++    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
++    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
++    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
++    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
++    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
++    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
++    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
++    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
++    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
++    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
++    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
++    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
++    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
++    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
++    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
++    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
++    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
++    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
++    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
++    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
++    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
++    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
++    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
++    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
++    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
++    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
++    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
++    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
++    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
++    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
++    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
++    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
++    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
++    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
++    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
++    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
++    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
++    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
++    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
++    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
++    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
++    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
++    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
++    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
++    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
++    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
++    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
++    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
++    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
++    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
++    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
++    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
++    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
++    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
++    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
++    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
++    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
++    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
++]
++
++[[package]]
++name = "mdit-py-plugins"
++version = "0.5.0"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "markdown-it-py" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
++]
++
++[[package]]
++name = "mdurl"
++version = "0.1.2"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
++]
++
++[[package]]
++name = "myst-parser"
++version = "5.0.0"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "docutils" },
++    { name = "jinja2" },
++    { name = "markdown-it-py" },
++    { name = "mdit-py-plugins" },
++    { name = "pyyaml" },
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl", hash = "sha256:ab31e516024918296e169139072b81592336f2fef55b8986aa31c9f04b5f7211", size = 84533, upload-time = "2026-01-15T09:08:16.788Z" },
++]
++
++[[package]]
++name = "packaging"
++version = "26.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
++]
++
++[[package]]
++name = "pygments"
++version = "2.19.2"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
++]
++
++[[package]]
++name = "pyyaml"
++version = "6.0.3"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
++    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
++    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
++    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
++    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
++    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
++    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
++    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
++    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
++    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
++    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
++    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
++    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
++    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
++    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
++    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
++    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
++    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
++    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
++    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
++    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
++    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
++    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
++    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
++    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
++    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
++    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
++    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
++    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
++    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
++    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
++    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
++    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
++    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
++    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
++    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
++    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
++    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
++    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
++    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
++    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
++    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
++    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
++    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
++    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
++    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
++    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
++]
++
++[[package]]
++name = "redirects-cli"
++version = "0.1.3"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "colorama" },
++    { name = "typer" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/f0/3e/942a3d5322f05aa75c903de1bdc101800cc0627e4c6c371768ef9070fa28/redirects_cli-0.1.3.tar.gz", hash = "sha256:0cc6f35ae372d087d56bc03cfc639d6e2eac0771454c3c173ac6f3dc233969bc", size = 4404, upload-time = "2022-11-29T19:11:20.776Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/3e/a4/829d6901e0c2c492d0d46190aadf3f4b9c6db6594b4e14a814f844014b28/redirects_cli-0.1.3-py3-none-any.whl", hash = "sha256:8a7a548d5f45b98db7d110fd8affbbb44b966cf250e35b5f4c9bd6541622272d", size = 4655, upload-time = "2022-11-29T19:11:18.898Z" },
++]
++
++[[package]]
++name = "requests"
++version = "2.32.5"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "certifi" },
++    { name = "charset-normalizer" },
++    { name = "idna" },
++    { name = "urllib3" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
++]
++
++[[package]]
++name = "rich"
++version = "14.3.3"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "markdown-it-py" },
++    { name = "pygments" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
++]
++
++[[package]]
++name = "roman-numerals"
++version = "4.1.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
++]
++
++[[package]]
++name = "setuptools"
++version = "82.0.1"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
++]
++
++[[package]]
++name = "shellingham"
++version = "1.5.4"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
++]
++
++[[package]]
++name = "snowballstemmer"
++version = "3.0.1"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
++]
++
++[[package]]
++name = "soupsieve"
++version = "2.8.3"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
++]
++
++[[package]]
++name = "sphinx"
++version = "9.0.4"
++source = { registry = "https://pypi.org/simple" }
++resolution-markers = [
++    "python_full_version < '3.12'",
++]
++dependencies = [
++    { name = "alabaster", marker = "python_full_version < '3.12'" },
++    { name = "babel", marker = "python_full_version < '3.12'" },
++    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
++    { name = "docutils", marker = "python_full_version < '3.12'" },
++    { name = "imagesize", marker = "python_full_version < '3.12'" },
++    { name = "jinja2", marker = "python_full_version < '3.12'" },
++    { name = "packaging", marker = "python_full_version < '3.12'" },
++    { name = "pygments", marker = "python_full_version < '3.12'" },
++    { name = "requests", marker = "python_full_version < '3.12'" },
++    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
++    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
++    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
++    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
++    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
++    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
++    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
++    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
++]
++
++[[package]]
++name = "sphinx"
++version = "9.1.0"
++source = { registry = "https://pypi.org/simple" }
++resolution-markers = [
++    "python_full_version >= '3.12'",
++]
++dependencies = [
++    { name = "alabaster", marker = "python_full_version >= '3.12'" },
++    { name = "babel", marker = "python_full_version >= '3.12'" },
++    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
++    { name = "docutils", marker = "python_full_version >= '3.12'" },
++    { name = "imagesize", marker = "python_full_version >= '3.12'" },
++    { name = "jinja2", marker = "python_full_version >= '3.12'" },
++    { name = "packaging", marker = "python_full_version >= '3.12'" },
++    { name = "pygments", marker = "python_full_version >= '3.12'" },
++    { name = "requests", marker = "python_full_version >= '3.12'" },
++    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
++    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
++    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
++    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
++    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
++    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
++    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
++    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
++]
++
++[[package]]
++name = "sphinx-autobuild"
++version = "2025.8.25"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "colorama" },
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++    { name = "starlette" },
++    { name = "uvicorn" },
++    { name = "watchfiles" },
++    { name = "websockets" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/d7/20/56411b52f917696995f5ad27d2ea7e9492c84a043c5b49a3a3173573cd93/sphinx_autobuild-2025.8.25-py3-none-any.whl", hash = "sha256:b750ac7d5a18603e4665294323fd20f6dcc0a984117026d1986704fa68f0379a", size = 12535, upload-time = "2025-08-25T18:44:54.164Z" },
++]
++
++[[package]]
++name = "sphinx-collapse"
++version = "0.1.4"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/14/a1/cb5bb03a5081bd1229b3296c2af347b4147017fdb62777d2aad855cd349f/sphinx_collapse-0.1.4.tar.gz", hash = "sha256:ba860e50839c026cd1abcc164e1e7cb18bcc11c8214150e34a6550461be3229f", size = 19412, upload-time = "2026-02-27T17:47:24.191Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/9a/18/277f4663c97073606917becab629938237f1e03952f4e339f8b7d1f3096b/sphinx_collapse-0.1.4-py3-none-any.whl", hash = "sha256:76e9fa531bafb4984d6ef5f3dbe311982837f5965b7a35eda013bbd9dd41445e", size = 4811, upload-time = "2026-02-27T17:47:22.622Z" },
++]
++
++[[package]]
++name = "sphinx-copybutton"
++version = "0.5.2"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
++]
++
++[[package]]
++name = "sphinx-docs"
++version = "0.1.0"
++source = { virtual = "." }
++dependencies = [
++    { name = "myst-parser" },
++    { name = "pygments" },
++    { name = "redirects-cli" },
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++    { name = "sphinx-autobuild" },
++    { name = "sphinx-multiversion-scylla" },
++    { name = "sphinx-scylladb-theme" },
++    { name = "sphinx-sitemap" },
++]
++
++[package.metadata]
++requires-dist = [
++    { name = "myst-parser", specifier = ">=5.0.0" },
++    { name = "pygments", specifier = ">=2.18.0" },
++    { name = "redirects-cli", specifier = ">=0.1.3" },
++    { name = "sphinx", specifier = ">=9.0" },
++    { name = "sphinx-autobuild", specifier = ">=2025.4.8" },
++    { name = "sphinx-multiversion-scylla", specifier = ">=0.3.7" },
++    { name = "sphinx-scylladb-theme", specifier = ">=1.9.1" },
++    { name = "sphinx-sitemap", specifier = ">=2.9.0" },
++]
++
++[[package]]
++name = "sphinx-last-updated-by-git"
++version = "0.3.8"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/03/fd/de1685b6dab173dff31da24e0d3b29f02873fc24a1cdbb7678721ddc8581/sphinx_last_updated_by_git-0.3.8.tar.gz", hash = "sha256:c145011f4609d841805b69a9300099fc02fed8f5bb9e5bcef77d97aea97b7761", size = 10785, upload-time = "2024-08-11T07:15:54.601Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/e1/fb/e496f16fa11fbe2dbdd0b5e306ede153dfed050aae4766fc89d500720dc7/sphinx_last_updated_by_git-0.3.8-py3-none-any.whl", hash = "sha256:6382c8285ac1f222483a58569b78c0371af5e55f7fbf9c01e5e8a72d6fdfa499", size = 8580, upload-time = "2024-08-11T07:15:53.244Z" },
++]
++
++[[package]]
++name = "sphinx-multiversion-scylla"
++version = "0.3.7"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/55/b1/83fb37f6c9038469b3bd01453875bb2127b3c03f9f41247394ad2063645c/sphinx_multiversion_scylla-0.3.7.tar.gz", hash = "sha256:fc1ddd58e82cfd8810c1be6db8717a244043c04c1c632e9bd1436415d1db0d3b", size = 12665, upload-time = "2026-02-27T18:43:17.849Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/a1/94/f5b6219ca1136dc0305aaf3fb6c96aa2dfe65224d6dc147e00a6485a1a22/sphinx_multiversion_scylla-0.3.7-py3-none-any.whl", hash = "sha256:6205d261a77c90b7ea3105311d1d56014736a5148966133c34344512bb8c4e4f", size = 12558, upload-time = "2026-02-27T18:43:16.988Z" },
++]
++
++[[package]]
++name = "sphinx-notfound-page"
++version = "1.1.0"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/6a/b2/67603444a8ee97b4a8ea71b0a9d6bab1727ed65e362c87e02f818ee57b8a/sphinx_notfound_page-1.1.0.tar.gz", hash = "sha256:913e1754370bb3db201d9300d458a8b8b5fb22e9246a816643a819a9ea2b8067", size = 7392, upload-time = "2025-01-28T18:45:02.871Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/cd/d4/019fe439c840a7966012bbb95ccbdd81c5c10271749706793b43beb05145/sphinx_notfound_page-1.1.0-py3-none-any.whl", hash = "sha256:835dc76ff7914577a1f58d80a2c8418fb6138c0932c8da8adce4d9096fbcd389", size = 8167, upload-time = "2025-01-28T18:45:00.465Z" },
++]
++
++[[package]]
++name = "sphinx-scylladb-theme"
++version = "1.9.1"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "beautifulsoup4" },
++    { name = "pyyaml" },
++    { name = "setuptools" },
++    { name = "sphinx-collapse" },
++    { name = "sphinx-copybutton" },
++    { name = "sphinx-notfound-page" },
++    { name = "sphinx-substitution-extensions" },
++    { name = "sphinx-tabs" },
++    { name = "sphinxcontrib-mermaid" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/d7/4e/e49e351d4c429b8fe3090657d39e956d53dff61187d783caac1cba81bd72/sphinx_scylladb_theme-1.9.1.tar.gz", hash = "sha256:2ba6367f005d2c68eee1916cc16385989b8e53bbddcc81193003bdeb3bd3415e", size = 1676201, upload-time = "2026-03-09T18:10:43.841Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/4f/30/2b2bae1b022d1fabef405a4857f160464548e08d924f24d0b26d0ca6a848/sphinx_scylladb_theme-1.9.1-py3-none-any.whl", hash = "sha256:6156d60befc3da03bd11991fec9bc590e27ce7cc4ab05aa334edd5611424b106", size = 1662204, upload-time = "2026-03-09T18:10:45.638Z" },
++]
++
++[[package]]
++name = "sphinx-sitemap"
++version = "2.9.0"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "sphinx-last-updated-by-git" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/61/17/56fe0f65e3567f829b2b4153a622be1d4b222b781e0d90d7db5a7738f30f/sphinx_sitemap-2.9.0.tar.gz", hash = "sha256:70f97bcdf444e3d68e118355cf82a1f54c4d3c03d651cd17fe87398b26e25e21", size = 6978, upload-time = "2025-10-06T00:24:00.036Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/e4/94/3c57e8b1985e755c48972e2ecd59526d4bf0b52a1fe805bc52a8e98cb92d/sphinx_sitemap-2.9.0-py3-none-any.whl", hash = "sha256:f1f1d3a9ad012ba17a7ef0b560d303bff2d0db26647567d6e810bcc754466664", size = 6218, upload-time = "2025-10-06T00:23:58.778Z" },
++]
++
++[[package]]
++name = "sphinx-substitution-extensions"
++version = "2026.1.12"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "beartype" },
++    { name = "docutils" },
++    { name = "myst-parser" },
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/ca/3e/a82aa5fed0d06161a89dc2f6971b160f837cad44f196c467fc6b2132acaa/sphinx_substitution_extensions-2026.1.12.tar.gz", hash = "sha256:25e0c6c40fbf9e1df593883da946879044a3bf8d85652c8c58f354a53575d736", size = 31676, upload-time = "2026-01-12T06:19:35.324Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/9b/5e/9caa7167d2ef2b60326765150d64513be1b61b1864ad58a92683578b2776/sphinx_substitution_extensions-2026.1.12-py2.py3-none-any.whl", hash = "sha256:9152beb4f0f5cab52057681b376a473fa6b997defc85d4ac154dd12b13a3e987", size = 8766, upload-time = "2026-01-12T06:19:33.541Z" },
++]
++
++[[package]]
++name = "sphinx-tabs"
++version = "3.5.0"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "docutils" },
++    { name = "pygments" },
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/ce/30/ca5b0de830f369968d8e3483dd45a8908fd10169c05cd9837f0bd075982e/sphinx_tabs-3.5.0.tar.gz", hash = "sha256:91dba1187e4c35fd37380a56ac228bbd54c6c649b2351829f3bf033718277537", size = 17006, upload-time = "2026-03-03T23:00:30.404Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/2e/45/6adc5efeb19fd5fed4027e520b5c668ce58236a2b271ade5533c4c116276/sphinx_tabs-3.5.0-py3-none-any.whl", hash = "sha256:154be49de4d5c8249ea08c5d9bf88ca8f9c31e00a178305a93cbc33e000339e5", size = 9871, upload-time = "2026-03-03T23:00:28.89Z" },
++]
++
++[[package]]
++name = "sphinxcontrib-applehelp"
++version = "2.0.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
++]
++
++[[package]]
++name = "sphinxcontrib-devhelp"
++version = "2.0.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
++]
++
++[[package]]
++name = "sphinxcontrib-htmlhelp"
++version = "2.1.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
++]
++
++[[package]]
++name = "sphinxcontrib-jsmath"
++version = "1.0.1"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
++]
++
++[[package]]
++name = "sphinxcontrib-mermaid"
++version = "2.0.1"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "jinja2" },
++    { name = "pyyaml" },
++    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
++    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/2b/ae/999891de292919b66ea34f2c22fc22c9be90ab3536fbc0fca95716277351/sphinxcontrib_mermaid-2.0.1.tar.gz", hash = "sha256:a21a385a059a6cafd192aa3a586b14bf5c42721e229db67b459dc825d7f0a497", size = 19839, upload-time = "2026-03-05T14:10:41.901Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl", hash = "sha256:9dca7fbe827bad5e7e2b97c4047682cfd26e3e07398cfdc96c7a8842ae7f06e7", size = 14064, upload-time = "2026-03-05T14:10:40.533Z" },
++]
++
++[[package]]
++name = "sphinxcontrib-qthelp"
++version = "2.0.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
++]
++
++[[package]]
++name = "sphinxcontrib-serializinghtml"
++version = "2.0.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
++]
++
++[[package]]
++name = "starlette"
++version = "0.52.1"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "anyio" },
++    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
++]
++
++[[package]]
++name = "typer"
++version = "0.24.1"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "annotated-doc" },
++    { name = "click" },
++    { name = "rich" },
++    { name = "shellingham" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
++]
++
++[[package]]
++name = "typing-extensions"
++version = "4.15.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
++]
++
++[[package]]
++name = "urllib3"
++version = "2.6.3"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
++]
++
++[[package]]
++name = "uvicorn"
++version = "0.41.0"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "click" },
++    { name = "h11" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
++]
++
++[[package]]
++name = "watchfiles"
++version = "1.1.1"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "anyio" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
++    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
++    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
++    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
++    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
++    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
++    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
++    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
++    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
++    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
++    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
++    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
++    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
++    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
++    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
++    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
++    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
++    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
++    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
++    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
++    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
++    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
++    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
++    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
++    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
++    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
++    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
++    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
++    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
++    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
++    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
++    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
++    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
++    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
++    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
++    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
++    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
++    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
++    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
++    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
++    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
++    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
++    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
++    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
++    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
++    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
++    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
++    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
++    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
++    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
++    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
++    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
++    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
++    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
++    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
++    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
++    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
++    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
++    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
++    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
++    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
++    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
++    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
++    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
++    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
++    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
++    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
++    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
++    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
++    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
++    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
++    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
++    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
++    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
++    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
++    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
++]
++
++[[package]]
++name = "websockets"
++version = "16.0"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
++    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
++    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
++    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
++    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
++    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
++    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
++    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
++    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
++    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
++    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
++    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
++    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
++    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
++    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
++    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
++    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
++    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
++    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
++    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
++    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
++    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
++    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
++    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
++    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
++    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
++    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
++    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
++    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
++    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
++    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
++    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
++    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
++    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
++    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
++    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
++    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
++    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
++    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
++    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
++    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
++    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
++    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
++    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
++    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
++    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
++    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
++    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
++    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
++    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
++    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
++]
+diff --git a/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj b/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj
+index 7019bfbd..d6d3903b 100644
+--- a/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj
++++ b/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj
+@@ -7,9 +7,9 @@
+   </PropertyGroup>
+
+   <ItemGroup>
+-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
++    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
++    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
++    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+   </ItemGroup>
+diff --git a/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj b/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj
+index b70ffd5c..ca67b808 100644
+--- a/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj
++++ b/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj
+@@ -8,8 +8,8 @@
+   </PropertyGroup>
+
+   <ItemGroup>
+-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
++    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
++    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+   </ItemGroup>
+
+ </Project>
+diff --git a/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj b/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj
+index bfc01118..6c4fbd1d 100644
+--- a/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj
++++ b/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj
+@@ -8,7 +8,7 @@
+   </PropertyGroup>
+
+   <ItemGroup>
+-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.0" />
++    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+   </ItemGroup>
+
+   <ItemGroup>
+diff --git a/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs b/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
+index 32804661..1f2fe762 100644
+--- a/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
++++ b/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
+@@ -53,12 +53,13 @@ namespace Cassandra.IntegrationTests.Data
+             var cmd = _connection.CreateCommand();
+
+             string keyspaceName = "keyspace_ado_1";
+-            cmd.CommandText = string.Format(TestUtils.CreateKeyspaceSimpleFormat, keyspaceName, 3);
++            cmd.CommandText = string.Format(TestUtils.CreateKeyspaceGenericFormat, keyspaceName, "NetworkTopologyStrategy",
++                                              string.Format("'replication_factor' : {0}", 3));
+             cmd.ExecuteNonQuery();
+
+             VerifyStatement(
+                 QueryType.Query,
+-                $"CREATE KEYSPACE \"{keyspaceName}\" WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : {3} }}",
++                $"CREATE KEYSPACE {keyspaceName} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {3} }}",
+                 1);
+
+             _connection.ChangeDatabase(keyspaceName);
+diff --git a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+index fdcbef3c..f2c44ee1 100644
+--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
++++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+@@ -34,21 +34,21 @@
+
+   <ItemGroup>
+     <PackageReference Include="App.Metrics" Version="3.2.0" />
+-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.13.0" />
+-    <PackageReference Include="SSH.NET" Version="2025.0.0" />
++    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
++    <PackageReference Include="SSH.NET" Version="2025.1.0" />
+     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
+     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+     <PackageReference Include="Moq" Version="4.20.72" />
+-    <PackageReference Include="NUnit" Version="4.4.0" />
+-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+-    <PackageReference Include="NunitXml.TestLogger" Version="6.1.0" />
++    <PackageReference Include="NUnit" Version="4.5.0" />
++    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
++    <PackageReference Include="NunitXml.TestLogger" Version="8.0.0" />
+     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
+     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+-    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+-    <PackageReference Include="XunitXml.TestLogger" Version="6.1.0" />
++    <PackageReference Include="System.ValueTuple" Version="4.6.2" />
++    <PackageReference Include="XunitXml.TestLogger" Version="8.0.0" />
+   </ItemGroup>
+   <ItemGroup Condition=" '$(TargetFramework)' == 'net6' Or '$(TargetFramework)' == 'net7' Or '$(TargetFramework)' == 'net8' Or '$(TargetFramework)' == 'net9'">
+     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+@@ -56,4 +56,4 @@
+   <ItemGroup>
+     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs b/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
+index 3d037119..79c9ebd8 100644
+--- a/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
+@@ -324,7 +324,7 @@ namespace Cassandra.IntegrationTests.Core
+
+         private void SetupForFrozenNestedCollectionTest(ISession session, string keyspaceName, string fqTableName)
+         {
+-            session.Execute(string.Format("CREATE KEYSPACE IF NOT EXISTS {0} WITH replication = {1};", keyspaceName, "{'class': 'SimpleStrategy', 'replication_factor' : 1}"));
++            session.Execute(string.Format("CREATE KEYSPACE IF NOT EXISTS {0} WITH replication = {1};", keyspaceName, "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}"));
+             session.Execute(string.Format("CREATE TABLE IF NOT EXISTS {0} " +
+                                           "(id int primary key, " +
+                                           "map1 map<text, frozen<list<text>>>," +
+diff --git a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+index f0f48646..c50994c6 100644
+--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+@@ -294,7 +294,7 @@ namespace Cassandra.IntegrationTests.Core
+             using (var connection = CreateConnection())
+             {
+                 await connection.Open().ConfigureAwait(false);
+-                await Query(connection, "CREATE KEYSPACE ks_conn_consume WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}")
++                await Query(connection, "CREATE KEYSPACE ks_conn_consume WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}")
+                     .ConfigureAwait(false);
+
+                 await Query(connection, "CREATE TABLE ks_conn_consume.tbl1 (id uuid primary key)").ConfigureAwait(false);
+@@ -516,9 +516,9 @@ namespace Cassandra.IntegrationTests.Core
+         public async Task SetKeyspace_Parallel_Calls_Serially_Executes()
+         {
+             const string queryKs1 = "create keyspace if not exists ks_to_switch_p1 WITH replication = " +
+-                                    "{'class': 'SimpleStrategy', 'replication_factor' : 1}";
++                                    "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+             const string queryKs2 = "create keyspace if not exists ks_to_switch_p2 WITH replication = " +
+-                                    "{'class': 'SimpleStrategy', 'replication_factor' : 1}";
++                                    "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+             // ReSharper disable AccessToDisposedClosure, AccessToModifiedClosure
+             using (var connection = CreateConnection())
+             {
+@@ -565,8 +565,8 @@ namespace Cassandra.IntegrationTests.Core
+         [Test]
+         public void SetKeyspace_Serial_Calls_Serially_Executes()
+         {
+-            const string queryKs1 = "create keyspace ks_to_switch_s1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
+-            const string queryKs2 = "create keyspace ks_to_switch_s2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
++            const string queryKs1 = "create keyspace ks_to_switch_s1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
++            const string queryKs2 = "create keyspace ks_to_switch_s2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+             using (var connection = CreateConnection())
+             {
+                 connection.Open().Wait();
+@@ -606,7 +606,7 @@ namespace Cassandra.IntegrationTests.Core
+         public void SetKeyspace_When_Disposing_Faults_Task()
+         {
+             //Invoke multiple times, as it involves different threads and can be scheduled differently
+-            const string queryKs = "create keyspace ks_to_switch_when1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
++            const string queryKs = "create keyspace ks_to_switch_when1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+             using (var connection = CreateConnection())
+             {
+                 connection.Open().Wait();
+diff --git a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+index 6f07ebc5..f611025c 100644
+--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+@@ -52,10 +52,10 @@ namespace Cassandra.IntegrationTests.Core
+             Assert.AreEqual(1, cluster.GetReplicas("ks2", new byte[] { 0, 0, 0, 1 }).Count);
+
+             const string createKeyspaceQuery = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
+-            session.Execute(string.Format(createKeyspaceQuery, "ks1", "SimpleStrategy", "'replication_factor' : 1"));
+-            session.Execute(string.Format(createKeyspaceQuery, "ks2", "SimpleStrategy", "'replication_factor' : 3"));
++            session.Execute(string.Format(createKeyspaceQuery, "ks1", "NetworkTopologyStrategy", "'replication_factor' : 1"));
++            session.Execute(string.Format(createKeyspaceQuery, "ks2", "NetworkTopologyStrategy", "'replication_factor' : 3"));
+             session.Execute(string.Format(createKeyspaceQuery, "ks3", "NetworkTopologyStrategy", "'dc1' : 1"));
+-            session.Execute(string.Format(createKeyspaceQuery, "\"KS4\"", "SimpleStrategy", "'replication_factor' : 3"));
++            session.Execute(string.Format(createKeyspaceQuery, "\"KS4\"", "NetworkTopologyStrategy", "'replication_factor' : 3"));
+             //Let the magic happen
+             Thread.Sleep(5000);
+             Assert.Greater(cluster.Metadata.GetKeyspaces().Count, initialLength);
+@@ -168,7 +168,7 @@ namespace Cassandra.IntegrationTests.Core
+             TestHelper.Invoke(() => session.Execute("SELECT key FROM system.local WHERE key='local'"), 10);
+             Assert.True(cluster.AllHosts().All(h => h.IsConsiderablyUp));
+             //When the host of the control connection is used
+-            //It can result that event UP is not fired as it is not received by the control connection (it reconnected but missed the event) 
++            //It can result that event UP is not fired as it is not received by the control connection (it reconnected but missed the event)
+             Assert.True(upEventFired || useControlConnectionHost);
+         }
+
+@@ -262,17 +262,18 @@ namespace Cassandra.IntegrationTests.Core
+         }
+
+         [Test]
+-        public void CheckSimpleStrategyKeyspace()
++        public void CheckNetworkTopologyStrategyKeyspace_SingleDatacenter()
+         {
+             ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(DefaultNodeCount);
+             var session = testCluster.Session;
+             bool durableWrites = Randomm.Instance.NextBoolean();
+             string keyspaceName = TestUtils.GetUniqueKeyspaceName();
+
+-            string strategyClass = ReplicationStrategies.SimpleStrategy;
++            string strategyClass = ReplicationStrategies.NetworkTopologyStrategy;
+             int replicationFactor = Randomm.Instance.Next(1, 21);
+             session.CreateKeyspace(keyspaceName,
+-                ReplicationStrategies.CreateSimpleStrategyReplicationProperty(replicationFactor),
++                ReplicationStrategies.CreateNetworkTopologyStrategyReplicationProperty(
++                    new Dictionary<string, int> { { "replication_factor", replicationFactor } }),
+                 durableWrites);
+             session.ChangeKeyspace(keyspaceName);
+
+@@ -340,11 +341,11 @@ namespace Cassandra.IntegrationTests.Core
+             ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(DefaultNodeCount);
+             var session = testCluster.Session;
+
+-            const string strategyClass = "SimpleStrategy";
++            const string strategyClass = "NetworkTopologyStrategy";
+             const bool durableWrites = false;
+             const int replicationFactor = 1;
+             string cql = string.Format(@"
+-                        CREATE KEYSPACE {0} 
++                        CREATE KEYSPACE {0}
+                         WITH replication = {{ 'class' : '{1}', 'replication_factor' : {2} }}
+                         AND durable_writes={3};", keyspaceName, strategyClass, 1, durableWrites);
+             session.Execute(cql);
+@@ -504,11 +505,11 @@ namespace Cassandra.IntegrationTests.Core
+             var testCluster = TestClusterManager.GetNonShareableTestCluster(3, DefaultMaxClusterCreateRetries, true, false);
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
++                "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};",
+                 "CREATE TABLE ks1.tbl1 (id uuid PRIMARY KEY, value text)",
+                 "SELECT * FROM ks1.tbl1",
+                 "SELECT * FROM ks1.tbl1 where id = d54cb06d-d168-45a0-b1b2-9f5c75435d3d",
+-                "CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
++                "CREATE KEYSPACE ks2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};",
+                 "CREATE TABLE ks2.tbl2 (id uuid PRIMARY KEY, value text)",
+                 "SELECT * FROM ks2.tbl2",
+                 "SELECT * FROM ks2.tbl2",
+@@ -545,22 +546,22 @@ namespace Cassandra.IntegrationTests.Core
+         }
+
+         /// Tests that materialized view metadata is being properly retrieved
+-        /// 
++        ///
+         /// GetMaterializedView_Should_Retrieve_View_Metadata tests that materialized view metadata is being properly populated by the driver.
+         /// It first creates a base table with some sample columns, and a materialized view based on those columns. It then verifies the various metadata
+-        /// associated with the view. 
+-        /// 
++        /// associated with the view.
++        ///
+         /// @since 3.0.0
+         /// @jira_ticket CSHARP-348
+         /// @expected_result Materialized view metadata is properly populated
+-        /// 
++        ///
+         /// @test_category metadata
+         [Test, TestCassandraVersion(3, 0)]
+         public void GetMaterializedView_Should_Retrieve_View_Metadata()
+         {
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE ks_view_meta WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
++                "CREATE KEYSPACE ks_view_meta WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
+                 "CREATE TABLE ks_view_meta.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
+                 "CREATE MATERIALIZED VIEW ks_view_meta.dailyhigh AS SELECT user FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC)"
+             };
+@@ -603,22 +604,22 @@ namespace Cassandra.IntegrationTests.Core
+         }
+
+         /// Tests that materialized view metadata with quoted identifiers is being retrieved
+-        /// 
+-        /// MaterializedView_Should_Retrieve_View_Metadata_Quoted_Identifiers tests that materialized view metadata with quoated identifiers is being 
++        ///
++        /// MaterializedView_Should_Retrieve_View_Metadata_Quoted_Identifiers tests that materialized view metadata with quoated identifiers is being
+         /// properly populated by the driver. It first creates a base table with some sample columns, where these columns have quoted identifers as their name.
+-        /// It then creates a materialized view based on those columns. It then verifies the various metadata associated with the view. 
+-        /// 
++        /// It then creates a materialized view based on those columns. It then verifies the various metadata associated with the view.
++        ///
+         /// @since 3.0.0
+         /// @jira_ticket CSHARP-348
+         /// @expected_result Materialized view metadata is properly populated
+-        /// 
++        ///
+         /// @test_category metadata
+         [Test, TestCassandraVersion(3, 0)]
+         public void MaterializedView_Should_Retrieve_View_Metadata_Quoted_Identifiers()
+         {
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE ks_view_meta2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
++                "CREATE KEYSPACE ks_view_meta2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
+                 @"CREATE TABLE ks_view_meta2.t1 (""theKey"" INT, ""the;Clustering"" INT, ""the Value"" INT, PRIMARY KEY (""theKey"", ""the;Clustering""))",
+                 @"CREATE MATERIALIZED VIEW ks_view_meta2.mv1 AS SELECT ""theKey"", ""the;Clustering"", ""the Value"" FROM t1 WHERE ""theKey"" IS NOT NULL AND ""the;Clustering"" IS NOT NULL AND ""the Value"" IS NOT NULL PRIMARY KEY (""theKey"", ""the;Clustering"")"
+             };
+diff --git a/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs b/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
+index 63f30358..fbd5dca8 100644
+--- a/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
+@@ -48,9 +48,9 @@ namespace Cassandra.IntegrationTests.Core
+         }
+
+         /** name of test: ParallelInsertTest
+-         * 
++         *
+          * @param nothingActually.
+-         * 
++         *
+          */
+         [Test]
+         public void ParallelInsertTest()
+@@ -59,7 +59,7 @@ namespace Cassandra.IntegrationTests.Core
+             ISession localSession = localCluster.Connect();
+             string keyspaceName = "kp_pi1_" + Randomm.RandomAlphaNum(10);
+
+-            localSession.Execute(string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};", keyspaceName));
++            localSession.Execute(string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};", keyspaceName));
+
+             TestUtils.WaitForSchemaAgreement(localCluster);
+             localSession.ChangeKeyspace(keyspaceName);
+@@ -105,7 +105,7 @@ namespace Cassandra.IntegrationTests.Core
+                             }
+
+                             ar[i] = localSession.BeginExecute(string.Format(@"
+-                                INSERT INTO {0} (tweet_id, author, isok, body) 
++                                INSERT INTO {0} (tweet_id, author, isok, body)
+                                 VALUES ({1},'test{2}',{3},'body{2}');",
+                                 tableName, Guid.NewGuid(), i, i % 2 == 0 ? "false" : "true"), ConsistencyLevel.One, null, null);
+                             Interlocked.MemoryBarrier();
+@@ -229,8 +229,8 @@ namespace Cassandra.IntegrationTests.Core
+             ISession localSession = localCluster.Connect();
+             string keyspaceName = "kp_mat_" + Randomm.RandomAlphaNum(8);
+             localSession.Execute(
+-                string.Format(@"CREATE KEYSPACE {0} 
+-                    WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};"
++                string.Format(@"CREATE KEYSPACE {0}
++                    WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};"
+                                 , keyspaceName));
+             localSession.ChangeKeyspace(keyspaceName);
+
+@@ -295,7 +295,7 @@ namespace Cassandra.IntegrationTests.Core
+             ISession localSession = localCluster.Connect();
+             string keyspaceName = "keyspace" + Guid.NewGuid().ToString("N").ToLower();
+             localSession.Execute(
+-                    string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};", keyspaceName));
++                    string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};", keyspaceName));
+             localSession.ChangeKeyspace(keyspaceName);
+
+             string tableName = "table" + Guid.NewGuid().ToString("N").ToLower();
+diff --git a/src/Cassandra.IntegrationTests/Core/PoolTests.cs b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+index 022a89d8..26e95ea0 100644
+--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+@@ -305,7 +305,7 @@ namespace Cassandra.IntegrationTests.Core
+             {
+                 var session = cluster.Connect();
+                 //Will wait for all the nodes to have the same schema
+-                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
++                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
+             }
+         }
+
+@@ -324,7 +324,7 @@ namespace Cassandra.IntegrationTests.Core
+             {
+                 var session = cluster.Connect();
+                 //Will wait for all the nodes to have the same schema
+-                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
++                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
+                 session.ChangeKeyspace("ks1");
+                 TestHelper.ParallelInvoke(() =>
+                 {
+diff --git a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+index 905b61d9..ab0c011d 100644
+--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+@@ -202,7 +202,7 @@ namespace Cassandra.IntegrationTests.Core
+
+                 // Create schema and insert data
+                 session1.Execute(
+-                    "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
++                    "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}");
+                 session1.ChangeKeyspace("ks1");
+                 session2.ChangeKeyspace("ks1");
+                 session1.Execute("CREATE TABLE table1 (id int PRIMARY KEY, a text, c text)");
+@@ -730,7 +730,7 @@ namespace Cassandra.IntegrationTests.Core
+                 .Build())
+             {
+                 var session = localCluster.Connect("system");
+-                session.Execute("CREATE KEYSPACE bound_changeks_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
++                session.Execute("CREATE KEYSPACE bound_changeks_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
+                 TestUtils.WaitForSchemaAgreement(localCluster);
+                 var ps = session.Prepare("SELECT * FROM system.local WHERE key='local'");
+                 session.ChangeKeyspace("bound_changeks_test");
+diff --git a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+index e494fb86..bc893ba9 100644
+--- a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+@@ -436,7 +436,7 @@ namespace Cassandra.IntegrationTests.Core
+         {
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
++                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta3 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
+                 "CREATE TABLE IF NOT EXISTS ks_view_meta3.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
+                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta3.monthlyhigh AS SELECT user, game, year, month, score, day FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND day IS NOT NULL PRIMARY KEY ((game, year, month), score, user, day) WITH CLUSTERING ORDER BY (score DESC, user DESC, day DESC) AND compaction = { 'class' : 'SizeTieredCompactionStrategy' }"
+             };
+@@ -489,7 +489,7 @@ namespace Cassandra.IntegrationTests.Core
+         {
+             var queries = new[]
+             {
+-                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta4 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
++                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta4 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
+                 "CREATE TABLE IF NOT EXISTS ks_view_meta4.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
+                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta4.dailyhigh AS SELECT user, game, year, month, day, score FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC, user DESC)",
+                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta4.alltimehigh AS SELECT * FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY (game, score, year, month, day, user) WITH CLUSTERING ORDER BY (score DESC, year DESC, month DESC, day DESC, user DESC)"
+diff --git a/src/Cassandra.IntegrationTests/Core/StressTests.cs b/src/Cassandra.IntegrationTests/Core/StressTests.cs
+index dbbc6735..6ace8ddd 100644
+--- a/src/Cassandra.IntegrationTests/Core/StressTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/StressTests.cs
+@@ -45,7 +45,7 @@ namespace Cassandra.IntegrationTests.Core
+                 var session = cluster.Connect();
+                 var uniqueKsName = "keyspace_" + Randomm.RandomAlphaNum(10);
+                 session.Execute(@"CREATE KEYSPACE " + uniqueKsName +
+-                                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};");
++                                " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};");
+                 session.ChangeKeyspace(uniqueKsName);
+
+                 var tableName = "table_" + Guid.NewGuid().ToString("N").ToLower();
+@@ -102,7 +102,7 @@ namespace Cassandra.IntegrationTests.Core
+                 var session = cluster.Connect();
+                 var uniqueKsName = "keyspace_" + Randomm.RandomAlphaNum(10);
+                 session.Execute(@"CREATE KEYSPACE " + uniqueKsName +
+-                    " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};");
++                    " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};");
+                 session.ChangeKeyspace(uniqueKsName);
+
+                 var tableName = "table_" + Guid.NewGuid().ToString("N").ToLower();
+diff --git a/src/Cassandra.IntegrationTests/Core/TypeSerializersTests.cs b/src/Cassandra.IntegrationTests/Core/TypeSerializersTests.cs
+index 1ada55e1..956a1b0c 100644
+--- a/src/Cassandra.IntegrationTests/Core/TypeSerializersTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/TypeSerializersTests.cs
+@@ -57,12 +57,18 @@ namespace Cassandra.IntegrationTests.Core
+         {
+             get
+             {
+-                return new[]
++                var setupQueries = new List<string>
+                 {
+                     "CREATE TABLE tbl_decimal (id uuid PRIMARY KEY, text_value text, value1 decimal, value2 decimal)",
+-                    "CREATE TABLE tbl_decimal_key (id decimal PRIMARY KEY)",
+-                    string.Format("CREATE TABLE tbl_custom (id uuid PRIMARY KEY, value '{0}')", CustomTypeName)
++                    "CREATE TABLE tbl_decimal_key (id decimal PRIMARY KEY)"
+                 };
++
++                if (!TestClusterManager.IsScylla)
++                {
++                    setupQueries.Add(string.Format("CREATE TABLE tbl_custom (id uuid PRIMARY KEY, value '{0}')", CustomTypeName));
++                }
++
++                return setupQueries.ToArray();
+             }
+         }
+
+@@ -372,7 +378,7 @@ namespace Cassandra.IntegrationTests.Core
+                 };
+         }
+
+-        [Test, TestCassandraVersion(5, 0), TestCaseSource(nameof(VectorTestCaseData))]
++        [Test, TestCassandraOrScyllaVersion(5, 0, 2025, 4), TestCaseSource(nameof(VectorTestCaseData))]
+         public void VectorSimpleStatementTest<T>(string cqlSubType, Func<T> elementGeneratorFn, Action<object, object> assertFn)
+         {
+             SetupVectorUdtSchema();
+@@ -393,7 +399,7 @@ namespace Cassandra.IntegrationTests.Core
+             vectorSimpleStmtTestFn((i, v) => new SimpleStatement(new Dictionary<string, object> { { "idx", i }, { "vec", v } }, $"INSERT INTO {tableName} (i, j) VALUES (:idx, :vec)"));
+         }
+
+-        [Test, TestCassandraVersion(5, 0), TestCaseSource(nameof(VectorTestCaseData))]
++        [Test, TestCassandraOrScyllaVersion(5, 0, 2025, 4), TestCaseSource(nameof(VectorTestCaseData))]
+         public void VectorSimpleStatementTestComplex<T>(string cqlSubType, Func<T> elementGeneratorFn, Action<object, object> assertFn)
+         {
+             SetupVectorUdtSchema();
+@@ -430,7 +436,7 @@ namespace Cassandra.IntegrationTests.Core
+                 $"INSERT INTO {tableNameComplex} (i, k, l) VALUES (:idx, :vec, :vecc)"));
+         }
+
+-        [Test, TestCassandraVersion(5, 0), TestCaseSource(nameof(VectorTestCaseData))]
++        [Test, TestCassandraOrScyllaVersion(5, 0, 2025, 4), TestCaseSource(nameof(VectorTestCaseData))]
+         public void VectorPreparedStatementTest<T>(string cqlSubType, Func<T> elementGeneratorFn, Action<object, object> assertFn)
+         {
+             SetupVectorUdtSchema();
+@@ -454,7 +460,7 @@ namespace Cassandra.IntegrationTests.Core
+             vectorPreparedStmtTestFn($"INSERT INTO {tableName} (i, j) VALUES (:idx, :vec)", (i, v, ps) => ps.Bind(new { idx = i, vec = v }));
+         }
+
+-        [Test, TestCassandraVersion(5, 0), TestCaseSource(nameof(VectorTestCaseData))]
++        [Test, TestCassandraOrScyllaVersion(5, 0, 2025, 4), TestCaseSource(nameof(VectorTestCaseData))]
+         public void VectorPreparedStatementTestComplex<T>(string cqlSubType, Func<T> elementGeneratorFn, Action<object, object> assertFn)
+         {
+             SetupVectorUdtSchema();
+@@ -499,7 +505,7 @@ namespace Cassandra.IntegrationTests.Core
+                 ));
+         }
+
+-        [Test, TestCassandraVersion(5, 0), TestCaseSource(nameof(VectorTestCaseData))]
++        [Test, TestCassandraOrScyllaVersion(5, 0, 2025, 4), TestCaseSource(nameof(VectorTestCaseData))]
+         public void VectorTestCollectionConversion<T>(string cqlSubType, Func<T> elementGeneratorFn, Action<object, object> assertFn)
+         {
+             SetupVectorUdtSchema();
+@@ -535,7 +541,7 @@ namespace Cassandra.IntegrationTests.Core
+             vectorPreparedStmtTestFn($"INSERT INTO {tableName} (i, j) VALUES (:idx, :vec)", (i, v, ps) => ps.Bind(new { idx = i, vec = v }));
+         }
+
+-        [Test, TestCassandraVersion(5, 0), TestCaseSource(nameof(VectorTestCaseData))]
++        [Test, TestCassandraOrScyllaVersion(5, 0, 2025, 4), TestCaseSource(nameof(VectorTestCaseData))]
+         public void VectorTestCollectionConversionComplex<T>(string cqlSubType, Func<T> elementGeneratorFn, Action<object, object> assertFn)
+         {
+             SetupVectorUdtSchema();
+@@ -598,7 +604,7 @@ namespace Cassandra.IntegrationTests.Core
+         }
+
+         [Test]
+-        [TestCassandraVersion(5, 0)]
++        [TestCassandraOrScyllaVersion(5, 0, 2025, 4)]
+         public void VectorFloatTest()
+         {
+             var tableName = TestUtils.GetUniqueTableName();
+diff --git a/src/Cassandra.IntegrationTests/Core/UdfTests.cs b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
+index a437dd07..be91b9e4 100644
+--- a/src/Cassandra.IntegrationTests/Core/UdfTests.cs
++++ b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
+@@ -69,7 +69,7 @@ namespace Cassandra.IntegrationTests.Core
+                 var session = cluster.Connect();
+                 var queries = new List<string>
+                 {
+-                    "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
++                    "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}",
+                     $"CREATE FUNCTION  ks_udf.return_one() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE {udfLanguage} AS 'return 1;'",
+                     $"CREATE FUNCTION  ks_udf.plus(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE {udfLanguage} AS 'return s+v;'",
+                     $"CREATE FUNCTION  ks_udf.plus(s bigint, v bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE {udfLanguage} AS 'return s+v;'",
+diff --git a/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs b/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs
+index 15e43ca2..b8178757 100644
+--- a/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs
++++ b/src/Cassandra.IntegrationTests/Linq/LinqTable/CreateTable.cs
+@@ -419,7 +419,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqTable
+             VerifyStatement(
+                 QueryType.Query,
+                 $"CREATE KEYSPACE \"{newUniqueKsName}\" " +
+-                "WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : '1'}" +
++                "WITH replication = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : '1'}" +
+                 " AND durable_writes = true",
+                 1);
+ 
+diff --git a/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs b/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
+index 6db465ca..bae62a0d 100644
+--- a/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
++++ b/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
+@@ -266,7 +266,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+         }
+
+         /// <summary>
+-        /// Successfully insert a new record into a table that was created with fluent mapping, 
++        /// Successfully insert a new record into a table that was created with fluent mapping,
+         /// using Session.Execute to insert an Insert object created with table.Insert()
+         /// </summary>
+         [Test, TestCassandraVersion(2, 0)]
+@@ -304,7 +304,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+         }
+
+         /// <summary>
+-        /// By default Linq preserves class param casing, but cqlpoco does not, 
++        /// By default Linq preserves class param casing, but cqlpoco does not,
+         /// so expect "unconfigured columnfamily" when trying to insert via cqlpoco using default settings
+         /// This also validates that a private class can be used by the CqlPoco client
+         /// </summary>
+@@ -476,7 +476,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+
+         /// Tests if timestamp is set on CqlQueryOptions.
+         ///
+-        /// The TIMESTAMP input is in microseconds. If not specified, the time (in microseconds) that the write occurred to the column is used. 
++        /// The TIMESTAMP input is in microseconds. If not specified, the time (in microseconds) that the write occurred to the column is used.
+         /// when all nodes in the cluster is down, given a set ReadTimeoutMillis of 3 seconds.
+         ///
+         /// @since 2.1
+@@ -557,8 +557,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+                 var session = cluster.Connect();
+                 session.CreateKeyspace(anotherKeyspace, new Dictionary<string, string>
+                 {
+-                    { "class", "SimpleStrategy"},
+-                    { "replication_factor", "3"}
++                    { "class", "NetworkTopologyStrategy" },
++                    { "replication_factor", "1"}
+                 });
+                 session.ChangeKeyspace(anotherKeyspace);
+
+@@ -593,7 +593,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+                 var batch = mapper.CreateBatch();
+                 batch.Insert(user1);
+                 batch.Insert(user2);
+-                var consistency = ConsistencyLevel.All;
++                var consistency = ConsistencyLevel.Three;
+                 batch.WithOptions(o => o.SetConsistencyLevel(consistency));
+                 //Timestamp for BATCH request is supported in Cassandra 2.1 or above.
+                 if (TestClusterManager.CassandraVersion > Version.Parse("2.1"))
+@@ -602,8 +602,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
+                     batch.WithOptions(o => o.SetTimestamp(timestamp));
+                 }
+                 var ex = Assert.Throws<UnavailableException>(() => mapper.Execute(batch));
+-                Assert.AreEqual(ConsistencyLevel.All, ex.Consistency,
+-                            "Consistency level of batch exception should be the same as specified at CqlQueryOptions: ALL");
++                Assert.AreEqual(ConsistencyLevel.Three, ex.Consistency,
++                            "Consistency level of batch exception should be the same as specified at CqlQueryOptions: THREE");
+                 Assert.AreEqual(3, ex.RequiredReplicas);
+                 Assert.AreEqual(1, ex.AliveReplicas);
+             }
+diff --git a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
+index 001fcaec..cbe0f560 100644
+--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
++++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
+@@ -70,7 +70,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count);
+ 
+                 Assert.IsNull(newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName));
+-                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+ 
+                 newSession.Execute(createKeyspaceCql);
+                 TestUtils.WaitForSchemaAgreement(newCluster);
+@@ -86,7 +86,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public void TokenMap_Should_NotUpdateExistingTokenMap_When_KeyspaceIsRemoved()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+ 
+@@ -111,7 +111,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public void TokenMap_Should_NotUpdateExistingTokenMap_When_KeyspaceIsChanged()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+ 
+@@ -131,7 +131,8 @@ namespace Cassandra.IntegrationTests.MetadataTests
+ 
+                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
+                 var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
+-                var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}";
++                var localDc = newCluster.AllHosts().First().Datacenter;
++                var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', '{localDc}' : 2}}";
+                 newSession.Execute(alterKeyspaceCql);
+                 TestUtils.WaitForSchemaAgreement(newCluster);
+                 TestHelper.RetryAssert(() =>
+@@ -150,11 +151,11 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public async Task TokenMap_Should_RefreshTokenMapForSingleKeyspace_When_RefreshSchemaWithKeyspaceIsCalled()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+             keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+ 
+@@ -189,11 +190,11 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public async Task TokenMap_Should_RefreshTokenMapForAllKeyspaces_When_RefreshSchemaWithoutKeyspaceIsCalled()
+         {
+             var keyspaceName1 = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName1} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName1} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             _session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(_cluster);
+ 
+diff --git a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
+index 8a5e3133..14f7018a 100644
+--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
++++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
+@@ -43,7 +43,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+             Assert.AreEqual(3, newCluster.Metadata.Hosts.Count);
+ 
+             Assert.IsNull(newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName));
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+ 
+             newSession.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(newCluster);
+@@ -65,7 +65,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public void TokenMap_Should_UpdateExistingTokenMap_When_KeyspaceIsRemoved()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             Session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(Cluster);
+ 
+@@ -86,7 +86,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+         public void TokenMap_Should_UpdateExistingTokenMap_When_KeyspaceIsChanged()
+         {
+             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
+-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+             Session.Execute(createKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(Cluster);
+ 
+@@ -101,7 +101,8 @@ namespace Cassandra.IntegrationTests.MetadataTests
+ 
+             Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
+             var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
+-            var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}";
++            var localDc = newCluster.AllHosts().First().Datacenter;
++            var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', '{localDc}' : 2}}";
+             newSession.Execute(alterKeyspaceCql);
+             TestUtils.WaitForSchemaAgreement(newCluster);
+             TestHelper.RetryAssert(() =>
+diff --git a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
+index ceaf7cd0..0b2fccb8 100644
+--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
++++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
+@@ -61,7 +61,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
+                 var sessionNotSync = ClusterObjNotSync.Connect();
+                 var sessionSync = ClusterObjSync.Connect();
+
+-                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
++                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
+                 sessionNotSync.Execute(createKeyspaceCql);
+
+                 TestUtils.WaitForSchemaAgreement(ClusterObjNotSync);
+diff --git a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+index 3fd11d5d..00f2f894 100644
+--- a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
++++ b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+@@ -57,8 +57,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+             }
+         }
+         /// <summary>
+-        /// Validate that no hops occur when inserting into a single partition 
+-        /// 
++        /// Validate that no hops occur when inserting into a single partition
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// </summary>
+@@ -91,8 +91,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+
+         /// <summary>
+-        /// Validate that no hops occur when inserting GUID values into the key 
+-        /// 
++        /// Validate that no hops occur when inserting GUID values into the key
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// </summary>
+@@ -128,8 +128,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+
+         /// <summary>
+-        /// Validate that no hops occur when inserting into a composite key 
+-        /// 
++        /// Validate that no hops occur when inserting into a composite key
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// </summary>
+@@ -202,8 +202,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+
+         /// <summary>
+-        /// Validate that no hops occur when inserting string values via a prepared statement 
+-        /// 
++        /// Validate that no hops occur when inserting string values via a prepared statement
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// @test_category prepared_statements
+@@ -242,8 +242,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+
+         /// <summary>
+-        /// Validate that no hops occur when inserting int values via a prepared statement 
+-        /// 
++        /// Validate that no hops occur when inserting int values via a prepared statement
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// @test_category prepared_statements
+@@ -279,8 +279,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+         }
+
+         /// <summary>
+-        /// Validate that hops occur when the wrong partition is targeted 
+-        /// 
++        /// Validate that hops occur when the wrong partition is targeted
++        ///
+         /// @test_category load_balancing:dc_aware,round_robin
+         /// @test_category replication_strategy
+         /// </summary>
+@@ -325,7 +325,14 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+                 var session = cluster.Connect();
+                 Assert.AreEqual(256, cluster.AllHosts().First().Tokens.Count());
+                 var ks = TestUtils.GetUniqueKeyspaceName();
+-                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 1}}");
++                if (TestClusterManager.IsScylla)
++                {
++                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}} AND tablets = {{'enabled': false}}");
++                }
++                else
++                {
++                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}}");
++                }
+                 session.ChangeKeyspace(ks);
+                 session.Execute("CREATE TABLE tbl1 (id uuid primary key)");
+                 var ps = session.Prepare("INSERT INTO tbl1 (id) VALUES (?)");
+@@ -365,7 +372,14 @@ namespace Cassandra.IntegrationTests.Policies.Tests
+                 // Connect without a keyspace
+                 var session = cluster.Connect();
+                 var ks = TestUtils.GetUniqueKeyspaceName();
+-                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}");
++                if (TestClusterManager.IsScylla)
++                {
++                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}} AND tablets = {{'enabled': false}}");
++                }
++                else
++                {
++                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}}");
++                }
+                 session.ChangeKeyspace(ks);
+                 session.Execute($"CREATE TABLE tbl1 (id uuid primary key)");
+                 var ps = session.Prepare($"INSERT INTO tbl1 (id) VALUES (?)");
+diff --git a/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs b/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
+index 4eae1549..c1db1663 100644
+--- a/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
++++ b/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
+@@ -72,7 +72,7 @@ namespace Cassandra.IntegrationTests
+             Assert.True(statementLWT.IsLwt, "LWT statement should be detected as LWT");
+         }
+
+-        [Test]
++        [Test, TestScyllaVersion(2026, 1)]
+         public void Should_Use_Only_One_Node_When_LWT_Detected()
+         {
+             _realCluster = TestClusterManager.CreateNew(3);
+@@ -84,7 +84,7 @@ namespace Cassandra.IntegrationTests
+
+             // Create keyspace and table
+             session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
+-            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 3}}");
++            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}");
+             session.Execute($"USE lwt_test");
+             session.Execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+@@ -125,7 +125,7 @@ namespace Cassandra.IntegrationTests
+
+             // Create keyspace and table
+             session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
+-            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 3}}");
++            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}");
+             session.Execute($"USE lwt_test");
+             session.Execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+diff --git a/src/Cassandra.IntegrationTests/ShardAwarenessTests.cs b/src/Cassandra.IntegrationTests/ShardAwarenessTests.cs
+index e4650359..33223b1d 100644
+--- a/src/Cassandra.IntegrationTests/ShardAwarenessTests.cs
++++ b/src/Cassandra.IntegrationTests/ShardAwarenessTests.cs
+@@ -26,7 +26,7 @@ namespace Cassandra.IntegrationTests
+         [Test]
+         public void CorrectShardInTracingTest()
+         {
+-            _realCluster = TestClusterManager.CreateNew();
++            _realCluster = TestClusterManager.CreateNew(1);
+             var cluster = ClusterBuilder()
+                           .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                           .AddContactPoint(_realCluster.InitialContactPoint)
+@@ -34,7 +34,7 @@ namespace Cassandra.IntegrationTests
+             var _session = cluster.Connect();
+
+             _session.Execute("DROP KEYSPACE IF EXISTS shardawaretest");
+-            _session.Execute("CREATE KEYSPACE shardawaretest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
++            _session.Execute("CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'} AND tablets = {'enabled': false}");
+             _session.Execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
+
+             var populateStatement = _session.Prepare("INSERT INTO shardawaretest.t (pk, ck, v) VALUES (?, ?, ?)");
+diff --git a/src/Cassandra.IntegrationTests/TestBase/TestCassandraOrScyllaVersion.cs b/src/Cassandra.IntegrationTests/TestBase/TestCassandraOrScyllaVersion.cs
+new file mode 100644
+index 00000000..87e26ffc
+--- /dev/null
++++ b/src/Cassandra.IntegrationTests/TestBase/TestCassandraOrScyllaVersion.cs
+@@ -0,0 +1,73 @@
++using System;
++using Cassandra.IntegrationTests.TestClusterManagement;
++using NUnit.Framework;
++using NUnit.Framework.Interfaces;
++
++namespace Cassandra.IntegrationTests.TestBase
++{
++    public class TestCassandraOrScyllaVersion : NUnitAttribute, IApplyToTest
++    {
++        public int CassandraMajor { get; }
++
++        public int CassandraMinor { get; }
++
++        public int CassandraBuild { get; }
++
++        public int ScyllaMajor { get; }
++
++        public int ScyllaMinor { get; }
++
++        public int ScyllaBuild { get; }
++
++        public Comparison Comparison { get; }
++
++        public TestCassandraOrScyllaVersion(
++            int cassandraMajor,
++            int cassandraMinor,
++            int scyllaMajor,
++            int scyllaMinor,
++            Comparison comparison = Comparison.GreaterThanOrEqualsTo)
++            : this(cassandraMajor, cassandraMinor, 0, scyllaMajor, scyllaMinor, 0, comparison)
++        {
++        }
++
++        public TestCassandraOrScyllaVersion(
++            int cassandraMajor,
++            int cassandraMinor,
++            int cassandraBuild,
++            int scyllaMajor,
++            int scyllaMinor,
++            int scyllaBuild,
++            Comparison comparison = Comparison.GreaterThanOrEqualsTo)
++        {
++            CassandraMajor = cassandraMajor;
++            CassandraMinor = cassandraMinor;
++            CassandraBuild = cassandraBuild;
++            ScyllaMajor = scyllaMajor;
++            ScyllaMinor = scyllaMinor;
++            ScyllaBuild = scyllaBuild;
++            Comparison = comparison;
++        }
++
++        public void ApplyToTest(NUnit.Framework.Internal.Test test)
++        {
++            if (!Applies(out string msg))
++            {
++                test.RunState = RunState.Ignored;
++                test.Properties.Set("_SKIPREASON", msg);
++            }
++        }
++
++        public bool Applies(out string msg)
++        {
++            if (TestClusterManager.IsScylla)
++            {
++                var expectedScyllaVersion = new Version(ScyllaMajor, ScyllaMinor, ScyllaBuild);
++                return TestScyllaVersion.VersionMatch(expectedScyllaVersion, Comparison, out msg);
++            }
++
++            var expectedCassandraVersion = new Version(CassandraMajor, CassandraMinor, CassandraBuild);
++            return TestCassandraVersion.VersionMatch(expectedCassandraVersion, Comparison, out msg);
++        }
++    }
++}
+diff --git a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+index 024dc895..1ce06798 100644
+--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
++++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+@@ -40,7 +40,8 @@ namespace Cassandra.IntegrationTests.TestBase
+         private const int DefaultSleepIterationMs = 1000;
+
+         public static readonly string CreateKeyspaceSimpleFormat =
+-            "CREATE KEYSPACE \"{0}\" WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : {1} }}";
++            "CREATE KEYSPACE \"{0}\" WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {1} }}" +
++            (TestClusterManager.IsScylla ? " AND tablets = {{'enabled': false}}" : "");
+
+         public static readonly string CreateKeyspaceGenericFormat = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
+
 diff --git a/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs b/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
-index 5acf9490..8591dde4 100644
+index 5acf9490..cb1c1bbe 100644
 --- a/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
 +++ b/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
 @@ -105,7 +105,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
@@ -7,7 +3844,262 @@ index 5acf9490..8591dde4 100644
                      testCluster.Create(1, null);
                      string versionString = testCluster.GetVersion(1);
 -                    _scyllaVersion = new Version(versionString);
-+                    _scyllaVersion = Version.Parse(versionString.Split('-')[0]);
++                    _scyllaVersion = Version.Parse(versionString.Split('-', '~')[0]);
                      return _scyllaVersion;
                  }
                  finally
+diff --git a/src/Cassandra.Tests/Cassandra.Tests.csproj b/src/Cassandra.Tests/Cassandra.Tests.csproj
+index 40246bea..cc260a25 100644
+--- a/src/Cassandra.Tests/Cassandra.Tests.csproj
++++ b/src/Cassandra.Tests/Cassandra.Tests.csproj
+@@ -27,11 +27,11 @@
+     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
+     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+     <PackageReference Include="Moq" Version="4.20.72" />
+-    <PackageReference Include="NUnit" Version="4.4.0" />
+-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+-    <PackageReference Include="NunitXml.TestLogger" Version="6.1.0" />
++    <PackageReference Include="NUnit" Version="4.5.0" />
++    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
++    <PackageReference Include="NunitXml.TestLogger" Version="8.0.0" />
+     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+-    <PackageReference Include="XunitXml.TestLogger" Version="6.1.0" />
++    <PackageReference Include="XunitXml.TestLogger" Version="8.0.0" />
+     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+     <ProjectReference Include="..\Extensions\Cassandra.OpenTelemetry\Cassandra.OpenTelemetry.csproj">
+       <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+diff --git a/src/Cassandra.Tests/FrameParserTests.cs b/src/Cassandra.Tests/FrameParserTests.cs
+index 0b84c715..c38ac25a 100644
+--- a/src/Cassandra.Tests/FrameParserTests.cs
++++ b/src/Cassandra.Tests/FrameParserTests.cs
+@@ -142,7 +142,7 @@ namespace Cassandra.Tests
+                              .Concat(Encoding.UTF8.GetBytes("COUNTER")); // WriteType text
+
+             var body = GetErrorBody(WriteFailureErrorCode, "Test error message", additional);
+-            var response = GetResponse(body);
++            var response = GetResponse(body, ProtocolVersion.V5);
+             var ex = IsErrorResponse<WriteFailureException>(response);
+             Assert.AreEqual(ConsistencyLevel.Quorum, ex.ConsistencyLevel);
+             Assert.AreEqual(2, ex.ReceivedAcknowledgements);
+diff --git a/src/Cassandra.Tests/TokenTests.cs b/src/Cassandra.Tests/TokenTests.cs
+index 94caf4a1..647dfb26 100644
+--- a/src/Cassandra.Tests/TokenTests.cs
++++ b/src/Cassandra.Tests/TokenTests.cs
+@@ -572,8 +572,7 @@ namespace Cassandra.Tests
+                                     }
+                                 }
+                             }
+-                            else
+-                            if (j % 2 == 0)
++                            else if (j % 2 == 0)
+                             {
+                                 if (bag.TryTake(out var ksName))
+                                 {
+diff --git a/src/Cassandra/Cassandra.csproj b/src/Cassandra/Cassandra.csproj
+index 94abc4f7..d6a54c20 100644
+--- a/src/Cassandra/Cassandra.csproj
++++ b/src/Cassandra/Cassandra.csproj
+@@ -36,12 +36,12 @@
+
+   <ItemGroup>
+     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
+-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.9" />
+-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
++    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.13" />
++    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.13" />
+     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" NoWarn="NU1903" />
+-    <PackageReference Include="System.Collections.Immutable" Version="9.0.9" />
+-    <PackageReference Include="System.Management" Version="9.0.9" />
++    <PackageReference Include="System.Collections.Immutable" Version="9.0.13" />
++    <PackageReference Include="System.Management" Version="9.0.13" />
+     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.9" />
++    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.13" />
+   </ItemGroup>
+ </Project>
+diff --git a/src/Cassandra/FrameReader.cs b/src/Cassandra/FrameReader.cs
+index cea8231f..8d8c8b02 100644
+--- a/src/Cassandra/FrameReader.cs
++++ b/src/Cassandra/FrameReader.cs
+@@ -48,7 +48,7 @@ namespace Cassandra
+
+         public byte ReadByte()
+         {
+-            _stream.Read(_buffer, 0, 1);
++            Utils.ReadExactly(_stream, _buffer, 0, 1);
+             return _buffer[0];
+         }
+
+@@ -57,7 +57,7 @@ namespace Cassandra
+         /// </summary>
+         public ushort ReadUInt16()
+         {
+-            _stream.Read(_buffer, 0, 2);
++            Utils.ReadExactly(_stream, _buffer, 0, 2);
+             return BeConverter.ToUInt16(_buffer);
+         }
+
+@@ -66,13 +66,13 @@ namespace Cassandra
+         /// </summary>
+         public short ReadInt16()
+         {
+-            _stream.Read(_buffer, 0, 2);
++            Utils.ReadExactly(_stream, _buffer, 0, 2);
+             return BeConverter.ToInt16(_buffer);
+         }
+
+         public int ReadInt32()
+         {
+-            _stream.Read(_buffer, 0, 4);
++            Utils.ReadExactly(_stream, _buffer, 0, 4);
+             return BeConverter.ToInt32(_buffer);
+         }
+
+@@ -91,7 +91,7 @@ namespace Cassandra
+         private string ReadStringByLength(int length)
+         {
+             var bytes = new byte[length];
+-            _stream.Read(bytes, 0, length);
++            Utils.ReadExactly(_stream, bytes, 0, length);
+             return Encoding.UTF8.GetString(bytes);
+         }
+
+@@ -122,14 +122,14 @@ namespace Cassandra
+             IPAddress ip;
+             if (length == 4)
+             {
+-                _stream.Read(_buffer, 0, length);
++                Utils.ReadExactly(_stream, _buffer, 0, length);
+                 ip = new IPAddress(_buffer);
+                 return new IPEndPoint(ip, ReadInt32());
+             }
+             if (length == 16)
+             {
+                 var buffer = new byte[16];
+-                _stream.Read(buffer, 0, length);
++                Utils.ReadExactly(_stream, buffer, 0, length);
+                 ip = new IPAddress(buffer);
+                 return new IPEndPoint(ip, ReadInt32());
+             }
+@@ -184,7 +184,7 @@ namespace Cassandra
+
+         public void Read(byte[] buffer, int offset, int count)
+         {
+-            _stream.Read(buffer, offset, count);
++            Utils.ReadExactly(_stream, buffer, offset, count);
+         }
+
+         /// <summary>
+@@ -193,7 +193,7 @@ namespace Cassandra
+         /// </summary>
+         internal object ReadFromBytes(byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+         {
+-            _stream.Read(buffer, offset, length);
++            Utils.ReadExactly(_stream, buffer, offset, length);
+             return _serializer.Deserialize(buffer, 0, length, typeCode, typeInfo);
+         }
+
+@@ -203,7 +203,7 @@ namespace Cassandra
+         /// </summary>
+         internal object ReadFromBytesEncrypted(string ks, string table, string column, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+         {
+-            _stream.Read(buffer, offset, length);
++            Utils.ReadExactly(_stream, buffer, offset, length);
+             return _serializer.DeserializeAndDecrypt(ks, table, column, buffer, 0, length, typeCode, typeInfo);
+         }
+     }
+diff --git a/src/Cassandra/FrameWriter.cs b/src/Cassandra/FrameWriter.cs
+index b5c0c19d..500a9ec8 100644
+--- a/src/Cassandra/FrameWriter.cs
++++ b/src/Cassandra/FrameWriter.cs
+@@ -49,7 +49,7 @@ namespace Cassandra
+         {
+             var buffer = new byte[_stream.Length];
+             _stream.Position = 0;
+-            _stream.Read(buffer, 0, buffer.Length);
++            Utils.ReadExactly(_stream, buffer, 0, _stream.Length > int.MaxValue ? int.MaxValue : (int)_stream.Length);
+             return buffer;
+         }
+
+diff --git a/src/Cassandra/Utils.cs b/src/Cassandra/Utils.cs
+index a2e03ad9..00fdb373 100644
+--- a/src/Cassandra/Utils.cs
++++ b/src/Cassandra/Utils.cs
+@@ -29,6 +29,31 @@ namespace Cassandra
+ {
+     internal static class Utils
+     {
++        /// <summary>
++        /// Reads exactly the specified number of bytes from the stream.
++        /// Throws an exception if the stream ends before reading all requested bytes.
++        ///
++        /// After deprecation of net6 to be replaced with Stream.ReadExactly
++        /// </summary>
++        internal static void ReadExactly(Stream stream, byte[] buffer, int offset, int count)
++        {
++            if (count == 0)
++            {
++                return;
++            }
++
++            int totalBytesRead = 0;
++            while (totalBytesRead < count)
++            {
++                var bytesRead = stream.Read(buffer, offset + totalBytesRead, count - totalBytesRead);
++                if (bytesRead == 0)
++                {
++                    throw new IOException($"Unexpected end of stream. Expected to read {count} bytes but only read {totalBytesRead} bytes.");
++                }
++                totalBytesRead += bytesRead;
++            }
++        }
++
+         public static string ConvertToCqlMap(IDictionary<string, string> source)
+         {
+             var sb = new StringBuilder("{");
+@@ -188,7 +213,7 @@ namespace Cassandra
+         {
+             var buffer = new byte[stream.Length - position];
+             stream.Position = position;
+-            stream.Read(buffer, 0, buffer.Length - position);
++            ReadExactly(stream, buffer, 0, buffer.Length - position);
+             return buffer;
+         }
+
+@@ -203,7 +228,7 @@ namespace Cassandra
+             {
+                 stream.Position = 0;
+                 var itemLength = (int)stream.Length;
+-                stream.Read(buffer, offset, itemLength);
++                ReadExactly(stream, buffer, offset, itemLength);
+                 offset += itemLength;
+             }
+             return buffer;
+diff --git a/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj b/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+index 0ae76297..0f0b54a4 100644
+--- a/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
++++ b/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+@@ -23,8 +23,8 @@
+   </PropertyGroup>
+
+   <ItemGroup>
+-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.9" />
+-    <PackageReference Include="OpenTelemetry.Api" Version="1.13.0" />
++    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
++    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+   </ItemGroup>
+
+   <ItemGroup>
+diff --git a/src/Cassandra/CqlQueryTools.cs b/src/Cassandra/CqlQueryTools.cs
+index 2ec84c89..b13c5893 100644
+--- a/src/Cassandra/CqlQueryTools.cs
++++ b/src/Cassandra/CqlQueryTools.cs
+@@ -75,7 +75,7 @@ namespace Cassandra
+         {
+             if (replication == null)
+             {
+-                replication = new Dictionary<string, string> { { "class", ReplicationStrategies.SimpleStrategy }, { "replication_factor", "1" } };
++                replication = new Dictionary<string, string> { { "class", ReplicationStrategies.NetworkTopologyStrategy }, { "replication_factor", "1" } };
+             }
+ 
+             return string.Format(


### PR DESCRIPTION
Add patches with moving from `SimpleStrategy` to `NetworkTopologyStrategy` and updating packages versions.