### PR TITLE
Add integration test parity for C# matrix

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,12 +49,45 @@ jobs:
       - name: Resolve latest driver ref
         if: ${{ inputs.driver_ref == '' }}
         id: get-driver-ref
-        uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
-        with:
-          source: github-tag
-          repo: ${{ inputs.driver_repository }}
-          filters: LAST
-          github-token: ${{ github.token }}
+        env:
+          DRIVER_REPOSITORY: ${{ inputs.driver_repository }}
+          DRIVER_TYPE: ${{ inputs.driver_type }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+
+          repository = os.environ["DRIVER_REPOSITORY"]
+          driver_type = os.environ["DRIVER_TYPE"]
+          pattern = (
+              re.compile(r"^v\d+\.\d+\.\d+\.\d+$")
+              if driver_type == "scylla"
+              else re.compile(r"^\d+\.\d+\.\d+$")
+          )
+
+          output = subprocess.check_output(
+              ["git", "ls-remote", "--tags", "--refs", f"https://github.com/{repository}.git"],
+              text=True,
+          )
+          tags = []
+          for line in output.splitlines():
+              tag = line.rsplit("/", maxsplit=1)[-1]
+              if pattern.match(tag):
+                  tags.append(tag)
+
+          if not tags:
+              raise SystemExit(f"Unable to resolve latest {driver_type} C# driver tag from {repository}")
+
+          def version_key(tag: str) -> tuple[int, ...]:
+              return tuple(int(part) for part in tag.removeprefix("v").split("."))
+
+          latest = max(tags, key=version_key)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"versions={json.dumps([latest])}\n")
+          PY
 
       - name: Select Scylla version query
         id: scylla-query

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,263 @@
+name: Integration Tests
+
+on:
+  workflow_call:
+    inputs:
+      driver_repository:
+        description: Driver repository to test, for example datastax/csharp-driver or scylladb/csharp-driver.
+        required: true
+        type: string
+      driver_type:
+        description: Driver family used by the matrix code.
+        required: true
+        type: string
+      driver_ref:
+        description: Driver git ref to test. When empty, the latest tag from the driver repository is used.
+        required: false
+        type: string
+        default: ""
+      scylla_version:
+        description: Scylla version or alias to test. Supported aliases are LATEST, PRIOR, LTS-LATEST, and LTS-PRIOR. When empty, LATEST is used.
+        required: false
+        type: string
+        default: ""
+      tests:
+        description: Optional test selector passed through to the runner.
+        required: false
+        type: string
+        default: "integration"
+
+permissions:
+  contents: read
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    env:
+      WORKSPACE: ${{ github.workspace }}
+      CCM_DIR: ${{ github.workspace }}/scylla-ccm
+      CSHARP_MATRIX_DIR: ${{ github.workspace }}
+      CSHARP_DRIVER_DIR: ${{ github.workspace }}/driver
+    steps:
+      - name: Checkout matrix
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve latest driver ref
+        if: ${{ inputs.driver_ref == '' }}
+        id: get-driver-ref
+        uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
+        with:
+          source: github-tag
+          repo: ${{ inputs.driver_repository }}
+          filters: LAST
+          github-token: ${{ github.token }}
+
+      - name: Select Scylla version query
+        id: scylla-query
+        env:
+          SCYLLA_VERSION: ${{ inputs.scylla_version }}
+        run: |
+          set -euo pipefail
+
+          target="${SCYLLA_VERSION:-LATEST}"
+          filters=""
+          fallback_repo=""
+          needs_resolution=true
+
+          case "$target" in
+            LTS-LATEST)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.1.LAST'
+              ;;
+            LTS-PRIOR)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST-1.1.LAST'
+              fallback_repo="scylladb/scylla-enterprise"
+              ;;
+            LATEST)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST'
+              ;;
+            PRIOR)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST-1'
+              ;;
+            *)
+              needs_resolution=false
+              ;;
+          esac
+
+          {
+            echo "target=$target"
+            echo "needs_resolution=$needs_resolution"
+            echo "repo=scylladb/scylla"
+            echo "fallback_repo=$fallback_repo"
+            echo "filters=$filters"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve Scylla version
+        if: ${{ steps.scylla-query.outputs.needs_resolution == 'true' }}
+        id: get-scylla-version
+        uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
+        with:
+          source: dockerhub-imagetag
+          repo: ${{ steps.scylla-query.outputs.repo }}
+          filters: ${{ steps.scylla-query.outputs.filters }}
+          github-token: ${{ github.token }}
+
+      - name: Resolve Scylla version fallback
+        if: ${{ steps.scylla-query.outputs.fallback_repo != '' && (steps.get-scylla-version.outputs.versions == '' || steps.get-scylla-version.outputs.versions == '[]') }}
+        id: get-scylla-version-fallback
+        uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
+        with:
+          source: dockerhub-imagetag
+          repo: ${{ steps.scylla-query.outputs.fallback_repo }}
+          filters: ${{ steps.scylla-query.outputs.filters }}
+          github-token: ${{ github.token }}
+
+      - name: Normalize inputs
+        id: resolve
+        env:
+          DRIVER_REF_INPUT: ${{ inputs.driver_ref }}
+          DRIVER_REF_LATEST: ${{ steps.get-driver-ref.outputs.versions }}
+          DRIVER_TYPE: ${{ inputs.driver_type }}
+          SCYLLA_VERSION_TARGET: ${{ steps.scylla-query.outputs.target }}
+          SCYLLA_VERSION_NEEDS_RESOLUTION: ${{ steps.scylla-query.outputs.needs_resolution }}
+          SCYLLA_VERSION_RESOLVED: ${{ steps.get-scylla-version.outputs.versions }}
+          SCYLLA_VERSION_FALLBACK: ${{ steps.get-scylla-version-fallback.outputs.versions }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+
+          def pick(input_value: str, latest_json: str, kind: str) -> str:
+              if input_value:
+                  return input_value
+              latest = json.loads(latest_json or "[]")
+              if not latest:
+                  raise SystemExit(f"Unable to resolve {kind}")
+              return latest[0]
+
+          def first_version(versions_json: str) -> str:
+              if not versions_json:
+                  return ""
+              versions = json.loads(versions_json)
+              if isinstance(versions, str):
+                  return versions
+              if isinstance(versions, list):
+                  return versions[0] if versions else ""
+              raise SystemExit(f"Unexpected get-version output: {versions!r}")
+
+          driver_ref = pick(os.environ["DRIVER_REF_INPUT"], os.environ.get("DRIVER_REF_LATEST"), "driver ref")
+          scylla_target = os.environ["SCYLLA_VERSION_TARGET"]
+          if os.environ["SCYLLA_VERSION_NEEDS_RESOLUTION"] == "true":
+              scylla_version = first_version(os.environ.get("SCYLLA_VERSION_RESOLVED", ""))
+              scylla_version = scylla_version or first_version(os.environ.get("SCYLLA_VERSION_FALLBACK", ""))
+              if not scylla_version:
+                  raise SystemExit(f"Unable to resolve Scylla version target {scylla_target}")
+          else:
+              scylla_version = scylla_target
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"driver_ref={driver_ref}\n")
+              fh.write(f"scylla_version_target={scylla_target}\n")
+              fh.write(f"scylla_version={scylla_version}\n")
+              artifact_suffix = re.sub(r"[^A-Za-z0-9_.-]+", "-", f"{os.environ['DRIVER_TYPE']}-{driver_ref}-{scylla_version}")
+              fh.write(f"artifact_suffix={artifact_suffix}\n")
+          PY
+
+      - name: Restore CCM download cache
+        id: ccm-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.ccm/scylla-repository
+          key: ccm-${{ runner.os }}-${{ steps.resolve.outputs.scylla_version }}
+
+      - name: Checkout driver repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.driver_repository }}
+          ref: ${{ steps.resolve.outputs.driver_ref }}
+          path: driver
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Restore NuGet package cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ inputs.driver_repository }}-${{ hashFiles('driver/**/*.csproj', 'driver/**/packages.lock.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ inputs.driver_repository }}-
+
+      - name: Checkout CCM repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: scylladb/scylla-ccm
+          path: scylla-ccm
+          persist-credentials: false
+
+      - name: Run integration tests
+        env:
+          DRIVER_REF: ${{ steps.resolve.outputs.driver_ref }}
+          DRIVER_TYPE: ${{ inputs.driver_type }}
+          SCYLLA_VERSION: ${{ steps.resolve.outputs.scylla_version }}
+          TESTS: ${{ inputs.tests }}
+        run: |
+          set -euo pipefail
+          args=(./scripts/run_test.sh python3 ./main.py /datastax-csharp-driver --checkout-ref "$DRIVER_REF" --driver-type "$DRIVER_TYPE" --scylla-version "$SCYLLA_VERSION")
+          if [ -n "$TESTS" ]; then
+            args+=(--tests "$TESTS")
+          fi
+          "${args[@]}"
+
+      - name: Upload integration test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-reports-${{ steps.resolve.outputs.artifact_suffix }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            test_results/
+            driver/**/TestResults/
+
+      - name: Upload CCM logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ccm-logs-${{ steps.resolve.outputs.artifact_suffix }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            ~/.ccm/*/node*/logs/**
+            ~/.ccm/*/*.log
+
+      - name: Inspect CCM download cache
+        id: ccm-snapshot
+        if: ${{ steps.ccm-cache.outputs.cache-hit != 'true' }}
+        run: |
+          set -euo pipefail
+
+          host_dir="$HOME/.ccm/scylla-repository"
+
+          if [ -d "$host_dir" ] && find "$host_dir" -mindepth 1 -type f -print -quit | grep -q .; then
+            file_count=$(find "$host_dir" -type f | wc -l | tr -d ' ')
+            echo "CCM cache available at $host_dir ($file_count files)"
+            echo "snapshot=true" >> "$GITHUB_OUTPUT"
+            echo "files=$file_count" >> "$GITHUB_OUTPUT"
+            du -sh "$host_dir" || true
+            exit 0
+          fi
+
+          echo "CCM cache contents were not available for snapshot"
+          echo "snapshot=false" >> "$GITHUB_OUTPUT"
+
+      - name: Save CCM download cache
+        if: ${{ steps.ccm-cache.outputs.cache-hit != 'true' && steps.ccm-snapshot.outputs.snapshot == 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.ccm/scylla-repository
+          key: ccm-${{ runner.os }}-${{ steps.resolve.outputs.scylla_version }}

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,0 +1,132 @@
+name: PR Integration Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    name: Detect PR changes
+    runs-on: ubuntu-latest
+    outputs:
+      runner_changed: ${{ steps.detect.outputs.runner_changed }}
+      scripts_image_source_changed: ${{ steps.detect.outputs.scripts_image_source_changed }}
+      scripts_image_changed: ${{ steps.detect.outputs.scripts_image_changed }}
+      version_count: ${{ steps.detect.outputs.version_count }}
+      version_matrix: ${{ steps.detect.outputs.version_matrix }}
+    steps:
+      - name: Checkout matrix
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Detect changed paths
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+          from urllib.request import Request, urlopen
+
+          sys.path.insert(0, os.environ["GITHUB_WORKSPACE"])
+          from scripts.pr_integration_changes import detect_changes
+
+          api_url = os.environ["GITHUB_API_URL"].rstrip("/")
+          repo = os.environ["GITHUB_REPOSITORY"]
+          pr_number = os.environ["PR_NUMBER"]
+          token = os.environ["GH_TOKEN"]
+
+          changed_files = []
+          page = 1
+          while True:
+              request = Request(
+                  f"{api_url}/repos/{repo}/pulls/{pr_number}/files?per_page=100&page={page}",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urlopen(request) as response:
+                  batch = json.load(response)
+              if not batch:
+                  break
+              changed_files.extend(item["filename"] for item in batch)
+              if len(batch) < 100:
+                  break
+              page += 1
+
+          outputs = detect_changes(changed_files, repo_root=Path("."))
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for name, value in outputs.items():
+                  output.write(f"{name}={value}\n")
+          PY
+
+  require-scripts-image:
+    name: Require scripts/image update
+    needs: changes
+    if: ${{ needs.changes.outputs.scripts_image_source_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check scripts/image changed
+        env:
+          SCRIPTS_IMAGE_CHANGED: ${{ needs.changes.outputs.scripts_image_changed }}
+        run: |
+          set -euo pipefail
+          if [ "$SCRIPTS_IMAGE_CHANGED" != "true" ]; then
+            echo "::error::Changes to Docker image inputs require scripts/image to be updated in the same PR."
+            exit 1
+          fi
+          echo "scripts/image was updated."
+
+  current-workflow:
+    needs: changes
+    if: ${{ needs.changes.outputs.runner_changed == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - driver_type: datastax
+            driver_repository: datastax/csharp-driver
+            scylla_version: LATEST
+          - driver_type: scylla
+            driver_repository: scylladb/csharp-driver
+            scylla_version: LATEST
+          - driver_type: scylla
+            driver_repository: scylladb/csharp-driver
+            scylla_version: PRIOR
+          - driver_type: scylla
+            driver_repository: scylladb/csharp-driver
+            scylla_version: LTS-LATEST
+          - driver_type: scylla
+            driver_repository: scylladb/csharp-driver
+            scylla_version: LTS-PRIOR
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      driver_repository: ${{ matrix.driver_repository }}
+      driver_type: ${{ matrix.driver_type }}
+      scylla_version: ${{ matrix.scylla_version }}
+
+  changed-driver-version-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.version_count != '0' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.changes.outputs.version_matrix) }}
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      driver_repository: ${{ matrix.driver_repository }}
+      driver_type: ${{ matrix.driver_type }}
+      driver_ref: ${{ matrix.driver_ref }}
+      scylla_version: LATEST

--- a/main.py
+++ b/main.py
@@ -21,10 +21,39 @@ class EmptyTestResult(Exception):
     pass
 
 
+def resolve_driver_version(repo_directory: str, checkout_ref: str, driver_type: str) -> str:
+    tag_pattern = "v[0-9]*" if driver_type == "scylla" else "[0-9]*"
+    try:
+        version = subprocess.check_output(
+            [
+                "git",
+                "-C",
+                repo_directory,
+                "describe",
+                "--tags",
+                "--abbrev=0",
+                "--match",
+                tag_pattern,
+                checkout_ref,
+            ],
+            text=True,
+            stderr=subprocess.STDOUT,
+        ).strip()
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(
+            f"Unable to resolve a {driver_type} C# driver version tag for ref "
+            f"'{checkout_ref}' in '{repo_directory}': {exc.output}"
+        ) from exc
+
+    if not version:
+        raise ValueError(f"Unable to resolve a driver version tag for ref '{checkout_ref}' in '{repo_directory}'")
+    return version
+
+
 def main(arguments: argparse.Namespace) -> int:
     status = 0
     results = dict()
-    driver_type = get_driver_type(arguments.csharp_driver_git)
+    driver_type = arguments.driver_type or get_driver_type(arguments.csharp_driver_git)
 
     for driver_version in arguments.versions:
         results[driver_version] = dict()
@@ -34,7 +63,8 @@ def main(arguments: argparse.Namespace) -> int:
                          driver_type=driver_type,
                          tag=driver_version,
                          tests=arguments.tests,
-                         scylla_version=arguments.scylla_version)
+                         scylla_version=arguments.scylla_version,
+                         checkout_ref=arguments.checkout_ref)
             try:
                 report = runner.run()
 
@@ -109,18 +139,28 @@ def get_arguments() -> argparse.Namespace:
                         help="Tests to run (default: integration)")
     parser.add_argument("--scylla-version", default=os.environ.get("SCYLLA_VERSION", None),
                         help="Relocatable Scylla version to use (or set via SCYLLA_VERSION env variable)")
+    parser.add_argument("--checkout-ref", default=None,
+                        help="Git ref to checkout before testing. When set, the version is resolved from this ref.")
+    parser.add_argument("--driver-type", choices=["datastax", "scylla"], default=None,
+                        help="Driver family. Defaults to deriving it from remote.origin.url.")
     parser.add_argument("--recipients",   nargs="+", default=None,
                         help="Email recipients for the test report")
     arguments = parser.parse_args()
+    if isinstance(arguments.tests, str):
+        arguments.tests = [arguments.tests]
     if not arguments.scylla_version:
         logging.error("--scylla-version is required if SCYLLA_VERSION environment variable is not set")
         sys.exit(1)
 
+    driver_type = arguments.driver_type or get_driver_type(arguments.csharp_driver_git)
+    arguments.driver_type = driver_type
     versions = str(arguments.versions).replace(" ", "")
-    if versions.isdigit():
+    if arguments.checkout_ref:
+        arguments.versions = [resolve_driver_version(arguments.csharp_driver_git, arguments.checkout_ref, driver_type)]
+    elif versions.isdigit():
         arguments.versions = extract_n_latest_repo_tags(
             repo_directory=arguments.csharp_driver_git,
-            driver_type=get_driver_type(arguments.csharp_driver_git),
+            driver_type=driver_type,
             latest_tags_size=int(versions))
     else:
         arguments.versions = versions.split(",")

--- a/processjunit.py
+++ b/processjunit.py
@@ -51,7 +51,9 @@ class ProcessJUnit:
                 if key == "failures" and testcase_keys[key] > 0 and self.ignore_set:
                     testcase_keys[key] = filter_out_ignored_failed_test()
 
-            # rust does not report "skipped" in the <testsuite> summary
+            testcase_keys["ignored_on_failure"] += sum(1 for _ in testsuite_element.iter("ignored_on_failure"))
+
+            # Some test loggers do not report "skipped" in the <testsuite> summary.
             if skipped := testsuite_element.iter("skipped"):
                 testcase_keys["skipped"] = sum(1 for _ in skipped)
 
@@ -98,22 +100,22 @@ class ProcessJUnit:
         for testsuite_element in tree.iter("testsuite"):
             testsuit_child = ElementTree.SubElement(new_tree, "testsuite", attrib=testsuite_element.attrib)
             for element in testsuite_element.iter("testcase"):
-                testcase_element = ElementTree.SubElement(testsuit_child, "testcase", attrib=element.attrib)
-                if len(list(element.iter())) == 2:
-                    element_test_details = list(element.iter())[1]
-                    tag_name = element_test_details.tag
-                    if (element_test_details.tag == "failure" and
+                testcase_attrib = dict(element.attrib)
+                if classname := testcase_attrib.get("classname"):
+                    testcase_attrib["classname"] = f"{self.tag}.{classname}"
+                testcase_element = ElementTree.SubElement(testsuit_child, "testcase", attrib=testcase_attrib)
+                for element_test_details in list(element):
+                    new_element_test_details = deepcopy(element_test_details)
+                    if (new_element_test_details.tag == "failure" and
                             element.attrib.get("name") in flaky_tests):
                         logging.info("Flaky test '%s' failed for %s driver version - marking as ignored. Failure message: %s",
-                                     element.attrib.get("name"), self.tag, element_test_details.text)
+                                     element.attrib.get("name"), self.tag, new_element_test_details.text)
                         # Change tag name to prevent test failure
-                        tag_name = "ignored_on_failure"
-                        # Decrease amount of failed tests that its failure is expected for the rust driver version
+                        new_element_test_details.tag = "ignored_on_failure"
+                        # Decrease amount of failed tests whose failure is expected for this driver version.
                         testsuit_child.attrib["failures"] = str(int(testsuit_child.attrib["failures"]) - 1)
 
-                    new_element_test_details = ElementTree.SubElement(
-                        testcase_element, tag_name, attrib=element_test_details.attrib)
-                    new_element_test_details.text = element_test_details.text
+                    testcase_element.append(new_element_test_details)
 
         with self.tests_result_xml.open(mode="w", encoding="utf-8") as file:
             file.write(minidom.parseString(

--- a/run.py
+++ b/run.py
@@ -3,10 +3,11 @@ import logging
 import os
 import re
 import shutil
+import shlex
 import subprocess
 from functools import cached_property
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Sequence
 
 import yaml
 from packaging.version import Version, InvalidVersion
@@ -15,13 +16,75 @@ from configurations import test_config_map
 from processjunit import ProcessJUnit
 
 
+IGNORE_TEST_CATEGORIES = ("ignore", "flaky")
+
+
+def _empty_ignore_tests() -> Dict[str, List[str]]:
+    return {category: [] for category in IGNORE_TEST_CATEGORIES}
+
+
+def load_ignore_tests(ignore_file: Path) -> Dict[str, List[str]]:
+    if not ignore_file.is_file():
+        return _empty_ignore_tests()
+
+    text = ignore_file.read_text(encoding="utf-8")
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if re.match(r"^\s*-\s+[^'\"#\n][^#\n]*\s+#\S", line):
+            raise ValueError(
+                f"Invalid test selector in '{ignore_file}' at line {line_number}: "
+                "entries containing '#' must be quoted"
+            )
+
+    content = yaml.safe_load(text)
+    if content is None:
+        return _empty_ignore_tests()
+    if not isinstance(content, dict):
+        raise ValueError(f"The '{ignore_file}' file must contain a YAML mapping")
+
+    tests = content.get("tests")
+    if tests is None:
+        return _empty_ignore_tests()
+    if not isinstance(tests, dict):
+        raise ValueError(f"The 'tests' entry in '{ignore_file}' must be a mapping")
+
+    result = _empty_ignore_tests()
+    seen = set()
+    invalid_entries = []
+    duplicates = []
+    for category in IGNORE_TEST_CATEGORIES:
+        entries = tests.get(category) or []
+        if not isinstance(entries, list):
+            raise ValueError(f"The 'tests.{category}' entry in '{ignore_file}' must be a list")
+
+        for index, test_name in enumerate(entries, start=1):
+            if not isinstance(test_name, str) or not test_name.strip():
+                invalid_entries.append(f"{category}[{index}]")
+                continue
+            test_name = test_name.strip()
+            if test_name in seen:
+                duplicates.append(test_name)
+                continue
+            seen.add(test_name)
+            result[category].append(test_name)
+
+    if invalid_entries or duplicates:
+        details = []
+        if invalid_entries:
+            details.append(f"empty or non-string entries at indexes: {', '.join(invalid_entries)}")
+        if duplicates:
+            details.append(f"duplicate entries: {', '.join(duplicates)}")
+        raise ValueError(f"Invalid ignore tests in '{ignore_file}': {'; '.join(details)}")
+
+    return result
+
+
 class Run:
-    def __init__(self, csharp_driver_git, driver_type, tag, tests, scylla_version):
+    def __init__(self, csharp_driver_git, driver_type, tag, tests, scylla_version, checkout_ref=None):
         self.driver_version = tag.split("-", maxsplit=1)[0]
-        self._full_driver_version = tag
-        self._csharp_driver_git = csharp_driver_git
+        self._full_driver_version = checkout_ref or tag
+        self._csharp_driver_git = Path(csharp_driver_git)
         self._scylla_version = scylla_version
-        self._tests = tests
+        self._tests = [tests] if isinstance(tests, str) else tests
         self._driver_type = driver_type
 
     @cached_property
@@ -53,13 +116,11 @@ class Run:
     @cached_property
     def ignore_tests(self) -> Dict[str, List[str]]:
         ignore_file = self.version_folder / "ignore.yaml"
-        if not ignore_file.exists():
+        if not ignore_file.is_file():
             logging.info("Cannot find ignore file for version '%s'", self.driver_version)
-            return {}
+            return _empty_ignore_tests()
 
-        with ignore_file.open(mode="r", encoding="utf-8") as file:
-            content = yaml.safe_load(file)
-        ignore_tests = content.get("tests", {'ignore': [], 'flaky': []})
+        ignore_tests = load_ignore_tests(ignore_file)
         if not ignore_tests.get("ignore", None):
             logging.info("The file '%s' for version tag '%s' doesn't contain any test to ignore",
                          ignore_file, self.driver_version)
@@ -74,19 +135,25 @@ class Run:
             env["BuildTarget"] = "net8"
         return env
 
-    def _run_command_in_shell(self, cmd: str) -> None:
-        logging.debug("Execute the cmd '%s'", cmd)
-        with subprocess.Popen(cmd, shell=True, executable="/bin/bash", env=self.environment,
-                              cwd=self._csharp_driver_git, stderr=subprocess.PIPE) as proc:
+    def _run_command(self, cmd: Sequence[str]) -> None:
+        cmd = [str(arg) for arg in cmd]
+        logging.debug("Execute the cmd '%s'", shlex.join(cmd))
+        with subprocess.Popen(cmd, env=self.environment, cwd=self._csharp_driver_git,
+                              stderr=subprocess.PIPE, text=True) as proc:
             _, stderr = proc.communicate()
         if proc.returncode != 0:
-            raise subprocess.CalledProcessError(proc.returncode, cmd, stderr)
+            raise subprocess.CalledProcessError(proc.returncode, cmd, stderr=stderr)
+
+    def _call_command(self, cmd: Sequence[str], env: Optional[Dict[str, str]] = None) -> int:
+        cmd = [str(arg) for arg in cmd]
+        logging.info("Running the command '%s'", shlex.join(cmd))
+        return subprocess.call(cmd, env=env or self.environment, cwd=self._csharp_driver_git)
 
     def _checkout_branch(self) -> bool:
         try:
-            self._run_command_in_shell("git checkout .")
+            self._run_command(["git", "checkout", "."])
             logging.info("git checkout to '%s' tag branch", self._full_driver_version)
-            self._run_command_in_shell(f"git checkout {self._full_driver_version}")
+            self._run_command(["git", "checkout", self._full_driver_version])
             return True
         except Exception as exc:
             logging.error("Failed to branch for version '%s', with: '%s'", self.driver_version, str(exc))
@@ -97,18 +164,18 @@ class Run:
             if file_path.name.startswith("patch"):
                 try:
                     logging.info("Show patch's statistics for file '%s'", file_path)
-                    self._run_command_in_shell(f"git apply --stat {file_path}")
+                    self._run_command(["git", "apply", "--stat", file_path])
                     logging.info("Detect patch's errors for file '%s'", file_path)
-                    self._run_command_in_shell(f"git apply --check {file_path}")
+                    self._run_command(["git", "apply", "--check", file_path])
                 except subprocess.CalledProcessError as exc:
-                        if 'tests/integration/conftest.py' in exc.stderr.decode():
-                            self._run_command_in_shell(f"rm tests/integration/conftest.py")
-                        else:
-                            logging.exception(
-                                "Failed to apply patch '%s' to version '%s'", file_path, self.driver_version)
-                        raise
+                    if "tests/integration/conftest.py" in (exc.stderr or ""):
+                        (self._csharp_driver_git / "tests/integration/conftest.py").unlink()
+                    else:
+                        logging.exception(
+                            "Failed to apply patch '%s' to version '%s'", file_path, self.driver_version)
+                    raise
                 logging.info("Applying patch file '%s'", file_path)
-                self._run_command_in_shell(f"patch -p1 -i {file_path}")
+                self._run_command(["patch", "-p1", "-i", file_path])
         return True
 
     @cached_property
@@ -141,13 +208,48 @@ class Run:
         if not simulacron_path.exists():
             logging.info("Simulacron version %s is not found. Downloading to %s.", version, str(simulacron_path))
             try:
-                self._run_command_in_shell(
-                    f"curl -sL -o {simulacron_path} "
-                    f"https://github.com/datastax/simulacron/releases/download/{version}/simulacron-standalone-{version}.jar")
+                self._run_command(
+                    [
+                        "curl",
+                        "-sL",
+                        "-o",
+                        simulacron_path,
+                        f"https://github.com/datastax/simulacron/releases/download/{version}/simulacron-standalone-{version}.jar",
+                    ])
             except Exception as exc:
                 logging.error("Failed to download Simulacron: %s", str(exc))
                 raise
         return str(simulacron_path)
+
+    def _restore_dotnet_dependencies(self) -> None:
+        for project in sorted((self._csharp_driver_git / "src").glob("**/*.csproj")):
+            self._call_command(["dotnet", "restore", project])
+
+    def _setup_development_snk(self) -> None:
+        snk_file = self._csharp_driver_git / "build/scylladb.snk"
+        if not snk_file.is_file():
+            shutil.copyfile(self._csharp_driver_git / "build/scylladb-dev.snk", snk_file)
+
+    def _ignore_filter(self) -> str:
+        ignore_tests = " & ".join(
+            f"FullyQualifiedName!~{test}" for test in self.ignore_tests.get("ignore") or [])
+        return f"({ignore_tests})" if ignore_tests else ""
+
+    def _test_command(self, test: str) -> List[str]:
+        test_config = test_config_map[test]
+        cmd = ["dotnet", "test", test_config.test_project]
+        cmd.extend(shlex.split(test_config.test_command_args))
+        cmd.extend(["-l", f"junit;LogFilePath={self.junit_dir / self.junit_file}"])
+        if ignore_filter := self._ignore_filter():
+            cmd.extend(["--filter", ignore_filter])
+        return cmd
+
+    def _test_environment(self, simulacron_path: str) -> Dict[str, str]:
+        return {
+            **self.environment,
+            "SIMULACRON_PATH": simulacron_path,
+            "CCM_DISTRIBUTION": "scylla",
+        }
 
     def run(self) -> ProcessJUnit | None:
         junit = ProcessJUnit(self.junit_dir / self.junit_file, self.driver_version, self.ignore_tests)
@@ -158,38 +260,18 @@ class Run:
             for test in self._tests:
                 test_config = test_config_map[test]
                 logging.info("Add JUnit logger for tests %s.", test)
-                add_junit_logger_cmd = f'dotnet add {test_config.test_project} package JUnitXml.TestLogger'
-                logging.info("Running the command '%s'", add_junit_logger_cmd)
-                subprocess.call(f"{add_junit_logger_cmd}", shell=True, executable="/bin/bash",
-                                env=self.environment, cwd=self._csharp_driver_git)
+                self._call_command(["dotnet", "add", test_config.test_project, "package", "JUnitXml.TestLogger"])
 
                 logging.info("Restore dotnet dependencies to finish all lazy initialization before tests are started.")
-                restore_cmd = "find src/ -name '*.csproj' -exec dotnet restore {} \\;"
-                logging.info("Running the command '%s'", restore_cmd)
-                subprocess.call(f"{restore_cmd}", shell=True, executable="/bin/bash",
-                                env=self.environment, cwd=self._csharp_driver_git)
+                self._restore_dotnet_dependencies()
 
                 # For ScyllaDB driver, ensure development SNK is set up before running tests
                 if self._driver_type == "scylla":
                     logging.info("Setting up development SNK for ScyllaDB driver")
-                    snk_cmd = "[ -f build/scylladb.snk ] || cp build/scylladb-dev.snk build/scylladb.snk"
-                    logging.info("Running the command '%s'", snk_cmd)
-                    subprocess.call(f"{snk_cmd}", shell=True, executable="/bin/bash",
-                                    env=self.environment, cwd=self._csharp_driver_git)
+                    self._setup_development_snk()
 
                 logging.info("Run tests for tag '%s'", test)
-                junit_logger = f'-l "junit;LogFilePath={self.junit_dir / self.junit_file}"'
-                ignore_tests = " & ".join(
-                    f"FullyQualifiedName!~{test}" for test in self.ignore_tests.get("ignore") or [])
-                ignore_filter = f"({ignore_tests})" if ignore_tests else ""
-
-                test_cmd = (
-                    f'SIMULACRON_PATH={simulacron_path} '
-                    f'CCM_DISTRIBUTION=scylla dotnet test {test_config.test_project} {test_config.test_command_args} {junit_logger} '
-                    f'--filter "{ignore_filter}"')
-                logging.info("Running the command '%s'", test_cmd)
-                subprocess.call(f"{test_cmd}", shell=True, executable="/bin/bash",
-                                env=self.environment, cwd=self._csharp_driver_git)
+                self._call_command(self._test_command(test), env=self._test_environment(simulacron_path))
             junit.save_after_analysis()
 
             try:

--- a/run.py
+++ b/run.py
@@ -80,7 +80,7 @@ def load_ignore_tests(ignore_file: Path) -> Dict[str, List[str]]:
 
 class Run:
     def __init__(self, csharp_driver_git, driver_type, tag, tests, scylla_version, checkout_ref=None):
-        self.driver_version = tag.split("-", maxsplit=1)[0]
+        self.driver_version = tag.removeprefix("v").split("-", maxsplit=1)[0]
         self._full_driver_version = checkout_ref or tag
         self._csharp_driver_git = Path(csharp_driver_git)
         self._scylla_version = scylla_version
@@ -128,12 +128,21 @@ class Run:
 
     @cached_property
     def environment(self) -> Dict:
-        env = {**os.environ, "SCYLLA_VERSION": self._scylla_version}
+        env = {**os.environ, "SCYLLA_VERSION": self._scylla_version_for_ccm()}
         # For ScyllaDB driver: set BuildTarget to net8 to avoid requiring .NET 9 SDK
         # ScyllaDB driver defaults to net9 when BuildTarget is not set
         if self._driver_type == "scylla":
             env["BuildTarget"] = "net8"
         return env
+
+    def _scylla_version_for_ccm(self) -> str:
+        if (
+                self._scylla_version
+                and ":" not in self._scylla_version
+                and os.environ.get("SCYLLA_UNIFIED_PACKAGE") is None
+        ):
+            return f"release:{self._scylla_version}"
+        return self._scylla_version
 
     def _run_command(self, cmd: Sequence[str]) -> None:
         cmd = [str(arg) for arg in cmd]

--- a/scripts/pr_integration_changes.py
+++ b/scripts/pr_integration_changes.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+REPOSITORIES = {
+    "datastax": "datastax/csharp-driver",
+    "scylla": "scylladb/csharp-driver",
+}
+
+IMAGE_SOURCE_PATHS = {"scripts/Dockerfile", "scripts/requirements.txt"}
+
+RUNNER_PATHS = {
+    ".github/workflows/integration-tests.yml",
+    ".github/workflows/pr-integration-tests.yml",
+    "scripts/run_test.sh",
+    "scripts/image",
+    *IMAGE_SOURCE_PATHS,
+}
+
+
+def is_runner_path(filename: str) -> bool:
+    return filename.endswith(".py") or filename in RUNNER_PATHS
+
+
+def driver_ref_for_version(driver_type: str, version: str) -> str:
+    if driver_type == "scylla" and not version.startswith("v"):
+        return f"v{version}"
+    return version
+
+
+def detect_changes(changed_files: Iterable[str], repo_root: Path = Path(".")) -> dict[str, str]:
+    repo_root = Path(repo_root)
+    changed_files = list(changed_files)
+
+    version_dirs = set()
+    for filename in changed_files:
+        parts = filename.split("/")
+        if len(parts) >= 3 and parts[0] == "versions":
+            path = repo_root / parts[0] / parts[1] / parts[2]
+            if path.is_dir():
+                version_dirs.add((parts[1], parts[2]))
+
+    version_matrix = []
+    for driver_type, version in sorted(version_dirs):
+        repository = REPOSITORIES.get(driver_type)
+        if repository is None:
+            raise SystemExit(f"Unsupported driver type in versions/{driver_type}/{version}")
+        version_matrix.append(
+            {
+                "driver_type": driver_type,
+                "driver_repository": repository,
+                "driver_version": version,
+                "driver_ref": driver_ref_for_version(driver_type, version),
+            }
+        )
+
+    runner_changed = any(is_runner_path(filename) for filename in changed_files)
+    scripts_image_source_changed = any(filename in IMAGE_SOURCE_PATHS for filename in changed_files)
+    scripts_image_changed = "scripts/image" in changed_files and (repo_root / "scripts/image").is_file()
+
+    matrix = {
+        "include": version_matrix
+        or [
+            {
+                "driver_type": "none",
+                "driver_repository": "none",
+                "driver_version": "none",
+                "driver_ref": "none",
+            }
+        ]
+    }
+
+    return {
+        "runner_changed": str(runner_changed).lower(),
+        "scripts_image_source_changed": str(scripts_image_source_changed).lower(),
+        "scripts_image_changed": str(scripts_image_changed).lower(),
+        "version_count": str(len(version_matrix)),
+        "version_matrix": json.dumps(matrix, separators=(",", ":")),
+    }

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -17,12 +17,17 @@ export CSHARP_MATRIX_DIR=${CSHARP_MATRIX_DIR:-`pwd`}
 export CSHARP_DRIVER_DIR=${CSHARP_DRIVER_DIR:-`pwd`/../datastax-csharp-driver}
 export CCM_DIR=${CCM_DIR:-`pwd`/../scylla-ccm}
 
-if [[ ! -d ${CSHARP_MATRIX_DIR} ]]; then
+if [[ ! -d "${CSHARP_MATRIX_DIR}" ]]; then
     echo -e "\e[31m\$CSHARP_MATRIX_DIR = $CSHARP_MATRIX_DIR doesn't exist\e[0m"
     echo "${help_text}"
     exit 1
 fi
-if [[ ! -d ${CCM_DIR} ]]; then
+if [[ ! -d "${CSHARP_DRIVER_DIR}" ]]; then
+    echo -e "\e[31m\$CSHARP_DRIVER_DIR = $CSHARP_DRIVER_DIR doesn't exist\e[0m"
+    echo "${help_text}"
+    exit 1
+fi
+if [[ ! -d "${CCM_DIR}" ]]; then
     echo -e "\e[31m\$CCM_DIR = $CCM_DIR doesn't exist\e[0m"
     echo "${help_text}"
     exit 1
@@ -40,7 +45,7 @@ JOB_OPTIONS=$(env | sed -n 's/^\(JOB_[^=]\+\)=.*/--env \1/p')
 AWS_OPTIONS=$(env | sed -n 's/^\(AWS_[^=]\+\)=.*/--env \1/p')
 
 # if in jenkins also mount the workspace into docker
-if [[ -d ${WORKSPACE} ]]; then
+if [[ -d ${WORKSPACE:-} ]]; then
 WORKSPACE_MNT="-v ${WORKSPACE}:${WORKSPACE}"
 else
 WORKSPACE_MNT=""
@@ -55,6 +60,20 @@ group_args=()
 for gid in $(id -G); do
     group_args+=(--group-add "$gid")
 done
+
+run_test_cmd=$(printf '%q ' "$@")
+container_cmd=$(cat <<'EOF'
+set -e
+pip install -e /scylla-ccm
+export PATH="$PATH:${HOME}/.local/bin"
+ln -sf /scylla-ccm/ccm /usr/local/bin/ccm
+set +e
+__RUN_TEST_CMD__
+status=$?
+exit "${status}"
+EOF
+)
+container_cmd=${container_cmd/__RUN_TEST_CMD__/${run_test_cmd}}
 
 docker_cmd="docker run --init --detach=true \
     ${WORKSPACE_MNT} \
@@ -84,7 +103,7 @@ docker_cmd="docker run --init --detach=true \
     -v ${HOME}/.local:${HOME}/.local \
     -v ${HOME}/.ccm:${HOME}/.ccm \
     --network=host --privileged \
-    ${DOCKER_IMAGE} bash -c 'pip install -e /scylla-ccm ; export PATH=\$PATH:\${HOME}/.local/bin ; ln -s /scylla-ccm/ccm /usr/local/bin/ccm; $*'"
+    ${DOCKER_IMAGE} bash -c $(printf '%q' "$container_cmd")"
 
 echo "Running Docker: $docker_cmd"
 container=$(eval $docker_cmd)

--- a/tests/test_datastax_patches.py
+++ b/tests/test_datastax_patches.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_datastax_patches_use_current_udf_feature_flag():
+    for patch_file in (REPO_ROOT / "versions" / "datastax").glob("*/patch"):
+        assert "experimental:true" not in patch_file.read_text(encoding="utf-8"), patch_file

--- a/tests/test_ignore_yaml.py
+++ b/tests/test_ignore_yaml.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from run import load_ignore_tests
+
+
+def test_load_ignore_tests_rejects_unquoted_method_selector(tmp_path):
+    ignore_file = tmp_path / "ignore.yaml"
+    ignore_file.write_text(
+        """\
+tests:
+  ignore:
+    - DriverIT #should_fail
+  flaky: []
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="entries containing '#' must be quoted"):
+        load_ignore_tests(ignore_file)
+
+
+def test_load_ignore_tests_rejects_empty_and_duplicate_entries(tmp_path):
+    ignore_file = tmp_path / "ignore.yaml"
+    ignore_file.write_text(
+        """\
+tests:
+  ignore:
+    - DriverIT
+    -
+  flaky:
+    - DriverIT
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="empty or non-string entries.*duplicate entries: DriverIT"):
+        load_ignore_tests(ignore_file)
+
+
+def test_load_ignore_tests_accepts_nested_ignore_and_flaky_lists(tmp_path):
+    ignore_file = tmp_path / "ignore.yaml"
+    ignore_file.write_text(
+        """\
+tests:
+  ignore:
+    - DriverIT
+  flaky:
+    - FlakyIT
+""",
+        encoding="utf-8",
+    )
+
+    assert load_ignore_tests(ignore_file) == {"ignore": ["DriverIT"], "flaky": ["FlakyIT"]}
+
+
+def test_all_ignore_files_are_valid():
+    for ignore_file in sorted((REPO_ROOT / "versions").glob("*/*/ignore.yaml")):
+        load_ignore_tests(ignore_file)

--- a/tests/test_pr_integration_changes.py
+++ b/tests/test_pr_integration_changes.py
@@ -1,0 +1,80 @@
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.pr_integration_changes import detect_changes
+
+
+def test_runner_changes_include_shell_wrapper_and_workflows():
+    for changed_file in [
+        "scripts/run_test.sh",
+        "scripts/image",
+        ".github/workflows/integration-tests.yml",
+        ".github/workflows/pr-integration-tests.yml",
+        "main.py",
+    ]:
+        outputs = detect_changes([changed_file], repo_root=REPO_ROOT)
+
+        assert outputs["runner_changed"] == "true", changed_file
+
+
+def test_changed_scylla_version_patch_expands_to_driver_matrix_entry():
+    outputs = detect_changes(["versions/scylla/3.22.0.3/patch"], repo_root=REPO_ROOT)
+
+    assert outputs["version_count"] == "1"
+    matrix = json.loads(outputs["version_matrix"])
+    assert matrix["include"] == [
+        {
+            "driver_type": "scylla",
+            "driver_repository": "scylladb/csharp-driver",
+            "driver_version": "3.22.0.3",
+            "driver_ref": "v3.22.0.3",
+        }
+    ]
+
+
+def test_changed_datastax_version_patch_expands_to_driver_matrix_entry():
+    outputs = detect_changes(["versions/datastax/3.22.0/patch"], repo_root=REPO_ROOT)
+
+    assert outputs["version_count"] == "1"
+    matrix = json.loads(outputs["version_matrix"])
+    assert matrix["include"] == [
+        {
+            "driver_type": "datastax",
+            "driver_repository": "datastax/csharp-driver",
+            "driver_version": "3.22.0",
+            "driver_ref": "3.22.0",
+        }
+    ]
+
+
+def test_ccm_cache_restore_and_save_use_the_same_path():
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/integration-tests.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["integration-test"]["steps"]
+    restore = next(step for step in steps if step.get("id") == "ccm-cache")
+    save = next(step for step in steps if step.get("name") == "Save CCM download cache")
+
+    assert restore["with"]["path"] == "~/.ccm/scylla-repository"
+    assert save["with"]["path"] == restore["with"]["path"]
+
+
+def test_integration_workflow_uploads_reports_after_failures():
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/integration-tests.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["integration-test"]["steps"]
+    reports = next(step for step in steps if step.get("name") == "Upload integration test reports")
+    ccm_logs = next(step for step in steps if step.get("name") == "Upload CCM logs")
+
+    for step in (reports, ccm_logs):
+        assert step["if"] == "${{ always() }}"
+        assert step["uses"].startswith("actions/upload-artifact@")
+        assert len(step["uses"].removeprefix("actions/upload-artifact@")) == 40
+
+    assert "test_results/" in reports["with"]["path"]
+    assert "driver/**/TestResults/" in reports["with"]["path"]
+    assert "~/.ccm/*/node*/logs/**" in ccm_logs["with"]["path"]

--- a/tests/test_pr_integration_changes.py
+++ b/tests/test_pr_integration_changes.py
@@ -78,3 +78,10 @@ def test_integration_workflow_uploads_reports_after_failures():
     assert "test_results/" in reports["with"]["path"]
     assert "driver/**/TestResults/" in reports["with"]["path"]
     assert "~/.ccm/*/node*/logs/**" in ccm_logs["with"]["path"]
+
+
+def test_integration_workflow_resolves_scylla_driver_v_tags():
+    workflow_text = (REPO_ROOT / ".github/workflows/integration-tests.yml").read_text(encoding="utf-8")
+
+    assert r"^v\d+\.\d+\.\d+\.\d+$" in workflow_text
+    assert "git\", \"ls-remote\", \"--tags\", \"--refs\"" in workflow_text

--- a/tests/test_processjunit.py
+++ b/tests/test_processjunit.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from xml.etree import ElementTree
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from processjunit import ProcessJUnit
+
+
+def write_junit_report(path: Path, failures: str = "1", include_error: bool = True) -> None:
+    errors = "1" if include_error else "0"
+    error_testcase = """\
+    <testcase classname="C.Tests" name="errors" time="0.200">
+      <error message="bad" type="RuntimeError">error line 1
+error line 2</error>
+      <system-err>stderr details</system-err>
+    </testcase>
+""" if include_error else ""
+    path.write_text(
+        f"""\
+<testsuites>
+  <testsuite name="CSharpTests" tests="2" errors="{errors}" skipped="0" failures="{failures}" time="1.500">
+    <testcase classname="C.Tests" name="fails" time="0.100">
+      <failure message="boom" type="AssertionError">stack line 1
+stack line 2</failure>
+      <system-out>stdout details</system-out>
+    </testcase>
+{error_testcase.rstrip()}
+  </testsuite>
+</testsuites>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_create_report_preserves_testcase_diagnostics(tmp_path):
+    junit_file = tmp_path / "datastax_3.22.0.xml"
+    write_junit_report(junit_file)
+
+    report = ProcessJUnit(junit_file_xml=junit_file, tag="3.22.0", ignore_set={"ignore": [], "flaky": []})
+
+    assert report.summary["testsuite_summary"] == {
+        "time": 1.5,
+        "tests": 2,
+        "errors": 1,
+        "skipped": 0,
+        "failures": 1,
+        "ignored_on_failure": 0,
+    }
+
+    root = ElementTree.parse(junit_file).getroot()
+    testcases = root.findall("./testsuite/testcase")
+    assert testcases[0].attrib["classname"] == "3.22.0.C.Tests"
+    assert testcases[0].find("failure").text == "stack line 1\nstack line 2"
+    assert testcases[0].find("system-out").text == "stdout details"
+    assert testcases[1].find("error").text == "error line 1\nerror line 2"
+    assert testcases[1].find("system-err").text == "stderr details"
+
+
+def test_flaky_failure_is_marked_ignored_on_failure(tmp_path):
+    junit_file = tmp_path / "scylla_3.22.0.3.xml"
+    write_junit_report(junit_file, include_error=False)
+
+    report = ProcessJUnit(junit_file_xml=junit_file, tag="3.22.0.3", ignore_set={"ignore": [], "flaky": ["fails"]})
+
+    assert report.summary["testsuite_summary"]["failures"] == 0
+    assert report.summary["testsuite_summary"]["ignored_on_failure"] == 1
+    assert not report.is_failed
+
+    root = ElementTree.parse(junit_file).getroot()
+    suite = root.find("./testsuite")
+    assert suite.attrib["failures"] == "0"
+    assert suite.find("./testcase/ignored_on_failure").text == "stack line 1\nstack line 2"
+
+
+def test_summary_counts_previously_marked_flaky_failures(tmp_path):
+    junit_file = tmp_path / "scylla_3.22.0.3.xml"
+    write_junit_report(junit_file, include_error=False)
+
+    report = ProcessJUnit(junit_file_xml=junit_file, tag="3.22.0.3", ignore_set={"ignore": [], "flaky": ["fails"]})
+    report.save_after_analysis()
+
+    assert report.summary["testsuite_summary"]["failures"] == 0
+    assert report.summary["testsuite_summary"]["ignored_on_failure"] == 1

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import run as run_module
+from run import Run
+
+
+def make_runner(tmp_path, tag="3.22.0.3", checkout_ref=None, driver_type="scylla"):
+    driver = tmp_path / "driver repo"
+    driver.mkdir()
+    return Run(
+        csharp_driver_git=driver,
+        driver_type=driver_type,
+        tag=tag,
+        tests=["integration"],
+        scylla_version="2026.1.3",
+        checkout_ref=checkout_ref,
+    )
+
+
+def test_test_command_keeps_filter_as_one_argv_entry(tmp_path):
+    runner = make_runner(tmp_path)
+    runner.__dict__["ignore_tests"] = {"ignore": ["BadTest; echo unsafe", "OtherTest"], "flaky": []}
+
+    cmd = runner._test_command("integration")
+
+    assert cmd[:3] == [
+        "dotnet",
+        "test",
+        "src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj",
+    ]
+    assert cmd[cmd.index("--filter") + 1] == (
+        "(FullyQualifiedName!~BadTest; echo unsafe & FullyQualifiedName!~OtherTest)"
+    )
+
+
+def test_test_command_omits_filter_when_no_ignores(tmp_path):
+    runner = make_runner(tmp_path)
+    runner.__dict__["ignore_tests"] = {"ignore": [], "flaky": []}
+
+    assert "--filter" not in runner._test_command("integration")
+
+
+def test_scylla_environment_sets_net8_build_target(tmp_path):
+    runner = make_runner(tmp_path, driver_type="scylla")
+
+    assert runner.environment["BuildTarget"] == "net8"
+
+
+def test_datastax_environment_does_not_set_build_target(tmp_path):
+    runner = make_runner(tmp_path, tag="3.22.0", driver_type="datastax")
+
+    assert "BuildTarget" not in runner.environment
+
+
+def test_ensure_simulacron_download_uses_argv_command(monkeypatch, tmp_path):
+    runner = make_runner(tmp_path)
+    commands = []
+
+    monkeypatch.setattr(run_module, "__file__", str(tmp_path / "run.py"))
+    monkeypatch.setattr(runner, "_run_command", lambda cmd: commands.append([str(arg) for arg in cmd]))
+
+    assert runner.ensure_simulacron("0.12.0") == str(tmp_path / "simulacron-standalone-0.12.0.jar")
+    assert commands == [
+        [
+            "curl",
+            "-sL",
+            "-o",
+            str(tmp_path / "simulacron-standalone-0.12.0.jar"),
+            "https://github.com/datastax/simulacron/releases/download/0.12.0/simulacron-standalone-0.12.0.jar",
+        ]
+    ]
+
+
+def test_run_command_invokes_subprocess_without_shell(monkeypatch, tmp_path):
+    runner = make_runner(tmp_path, checkout_ref="feature/ref; echo unsafe")
+    captured = {}
+
+    class FakeProcess:
+        returncode = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def communicate(self):
+            return None, ""
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    runner._run_command(["git", "checkout", runner._full_driver_version])
+
+    assert captured["cmd"] == ["git", "checkout", "feature/ref; echo unsafe"]
+    assert "shell" not in captured["kwargs"]
+    assert captured["kwargs"]["cwd"] == tmp_path / "driver repo"

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -46,16 +46,38 @@ def test_test_command_omits_filter_when_no_ignores(tmp_path):
     assert "--filter" not in runner._test_command("integration")
 
 
+def test_scylla_v_tag_uses_unprefixed_version_folder_name(tmp_path):
+    runner = make_runner(tmp_path, tag="v3.22.0.3")
+
+    assert runner.driver_version == "3.22.0.3"
+
+
 def test_scylla_environment_sets_net8_build_target(tmp_path):
     runner = make_runner(tmp_path, driver_type="scylla")
 
     assert runner.environment["BuildTarget"] == "net8"
+    assert runner.environment["SCYLLA_VERSION"] == "release:2026.1.3"
 
 
 def test_datastax_environment_does_not_set_build_target(tmp_path):
     runner = make_runner(tmp_path, tag="3.22.0", driver_type="datastax")
 
     assert "BuildTarget" not in runner.environment
+    assert runner.environment["SCYLLA_VERSION"] == "release:2026.1.3"
+
+
+def test_scylla_version_preserves_explicit_ccm_prefix(tmp_path):
+    runner = make_runner(tmp_path)
+    runner._scylla_version = "unstable/master:2026-06-26"
+
+    assert runner.environment["SCYLLA_VERSION"] == "unstable/master:2026-06-26"
+
+
+def test_scylla_version_preserves_local_package_version(monkeypatch, tmp_path):
+    monkeypatch.setenv("SCYLLA_UNIFIED_PACKAGE", "/tmp/scylla-unified.tar.gz")
+    runner = make_runner(tmp_path)
+
+    assert runner.environment["SCYLLA_VERSION"] == "2026.1.3"
 
 
 def test_ensure_simulacron_download_uses_argv_command(monkeypatch, tmp_path):

--- a/tests/test_run_test_script.py
+++ b/tests/test_run_test_script.py
@@ -1,0 +1,86 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_run_test_constructs_one_docker_command_with_workspace_env(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    calls_file = tmp_path / "docker.calls"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -e
+            command="$1"
+            printf '%q' "$1" >> "${FAKE_DOCKER_CALLS}"
+            shift
+            for arg in "$@"; do
+              printf ' %q' "$arg" >> "${FAKE_DOCKER_CALLS}"
+            done
+            printf '\\n' >> "${FAKE_DOCKER_CALLS}"
+            case "$command" in
+              run)
+                printf 'fake-container\\n'
+                ;;
+              logs)
+                exit 0
+                ;;
+              wait)
+                printf '0\\n'
+                ;;
+              rm)
+                exit 0
+                ;;
+              *)
+                echo "unexpected docker command: $*" >&2
+                exit 2
+                ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_docker.chmod(0o755)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    ccm_dir = tmp_path / "scylla-ccm"
+    ccm_dir.mkdir()
+    driver_dir = tmp_path / "csharp-driver"
+    driver_dir.mkdir()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(home),
+            "CCM_DIR": str(ccm_dir),
+            "CSHARP_DRIVER_DIR": str(driver_dir),
+            "CSHARP_MATRIX_DIR": str(REPO_ROOT),
+            "SCYLLA_VERSION": "2026.1.3",
+            "FAKE_DOCKER_CALLS": str(calls_file),
+        }
+    )
+    env.pop("WORKSPACE", None)
+
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/run_test.sh"), "python3", "-c", "print('ok')"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout
+    calls = calls_file.read_text(encoding="utf-8").splitlines()
+    assert calls[0].startswith("run ")
+    assert " -e WORKSPACE " in f" {calls[0]} "
+    assert calls[1:] == ["logs fake-container -f", "wait fake-container", "rm -f fake-container"]

--- a/versions/scylla/3.22.0.3/ignore.yaml
+++ b/versions/scylla/3.22.0.3/ignore.yaml
@@ -67,3 +67,9 @@ tests:
   flaky:
     # due to https://github.com/scylladb/csharp-driver/issues/202
     - TokenMap_Should_RebuildTokenMap_When_NodeIsDecommissioned
+
+    # Scylla 2025.1 rejects LWT on tablets
+    - DeleteIf_Applied_Test
+    - InsertIfNotExists_Applied_Test
+    - UpdateIf_Applied_Test
+    - AddOpenTelemetry_MapperAndMapperAsync_SessionRequestIsParentOfNodeRequest


### PR DESCRIPTION
## Summary
- add PR integration workflows and change detection for the C# driver matrix
- port Java matrix pytest coverage to C#-specific runner, ignore YAML, JUnit, shell wrapper, patch, and PR workflow contracts
- harden runner command execution, checkout-ref handling, ignore validation, and JUnit diagnostics preservation

## Tests
- python3 -m pytest -q
- git diff --check
- bash -n scripts/run_test.sh