### PR TITLE
Fix CI failure and add ignore file for scylla driver 3.22.0.4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,7 +113,7 @@ jobs:
               filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST'
               ;;
             PRIOR)
-              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST-1'
+              filters='^[0-9]{4}$.^[0-9]+$.LAST and LAST-1'
               ;;
             *)
               needs_resolution=false

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -22,10 +22,13 @@ if [[ ! -d "${CSHARP_MATRIX_DIR}" ]]; then
     echo "${help_text}"
     exit 1
 fi
-if [[ ! -d "${CSHARP_DRIVER_DIR}" ]]; then
-    echo -e "\e[31m\$CSHARP_DRIVER_DIR = $CSHARP_DRIVER_DIR doesn't exist\e[0m"
-    echo "${help_text}"
-    exit 1
+# Mount the driver source only when it exists locally. In CI the driver is
+# passed as an absolute path argument and reached via the workspace mount, so
+# CSHARP_DRIVER_DIR is left unset and its default path may not exist.
+if [[ -d "${CSHARP_DRIVER_DIR}" ]]; then
+    CSHARP_DRIVER_MNT="-v ${CSHARP_DRIVER_DIR}:/datastax-csharp-driver"
+else
+    CSHARP_DRIVER_MNT=""
 fi
 if [[ ! -d "${CCM_DIR}" ]]; then
     echo -e "\e[31m\$CCM_DIR = $CCM_DIR doesn't exist\e[0m"
@@ -80,7 +83,7 @@ docker_cmd="docker run --init --detach=true \
     ${SCYLLA_OPTIONS} \
     ${DOCKER_CONFIG_MNT} \
     -v ${CSHARP_MATRIX_DIR}:/csharp-driver-matrix \
-    -v ${CSHARP_DRIVER_DIR}:/datastax-csharp-driver \
+    ${CSHARP_DRIVER_MNT} \
     -v ${CCM_DIR}:/scylla-ccm \
     -e HOME \
     -e SCYLLA_EXT_OPTS \

--- a/versions/scylla/3.22.0.4/ignore.yaml
+++ b/versions/scylla/3.22.0.4/ignore.yaml
@@ -1,0 +1,75 @@
+# Last verified state on Dec XX, 2024 by Dmytro Kruglov
+tests:
+  ignore:
+    # unrecognised option '-Dcassandra.custom_query_handler_class'
+    - ClientWarningsTests
+    - CustomPayloadTests
+
+    # CCM with SSL is not configured
+    - Connect_With_Ssl_Test
+
+    # ccm: no such option: --skip-wait-other-notice
+    - Should_UpdateHosts_When_HostIpChanges
+
+    # error: unrecognised option '-Dcassandra.override_decommission'
+    - Should_UseNewHostInQueryPlans_When_HostIsDecommissionedAndJoinsAgain
+    - Should_RemoveNodeMetricsAndDisposeMetricsContext_When_HostIsRemoved
+
+    # Cassandra only (C* virtual tables)
+    - Virtual_Keyspaces_Are_Included
+    - Virtual_Table_Metadata_Test
+
+    # unrecognised option '-Dcassandra.superuser_setup_delay_ms'
+    - SessionAuthenticationTests
+
+    # Cassandra only; no support for DynamicCompositeType in Scylla (https://github.com/scylladb/scylladb/issues/1677)
+    - TypeSerializersTests
+    - Custom_MetadataTest
+
+    # Cassandra only; no support for vector searched in Scylla
+    - LinqWhere_WithVectors
+
+    # COMPACT STORAGE is deprecated in Scylla (https://github.com/scylladb/scylladb/issues/12263)
+    - SimpleStatement_With_No_Compact_Enabled_Should_Reveal_Non_Schema_Columns
+    - SimpleStatement_With_No_Compact_Disabled_Should_Not_Reveal_Non_Schema_Columns
+
+    # dclocal_read_repair_chance and read_repair_chance are removed in Scylla 6.1 (https://github.com/scylladb/scylladb/pull/18087)
+    - ColumnClusteringOrderReversedTest
+    - GetMaterializedView_Should_Refresh_View_Metadata_Via_Events
+    - MaterializedView_Base_Table_Column_Addition
+    - MultipleSecondaryIndexTest
+    - RaiseErrorOnInvalidMultipleSecondaryIndexTest
+    - TableMetadataAllTypesTest
+    - TableMetadataClusteringOrderTest
+    - TableMetadataCollectionsSecondaryIndexTest
+    - TableMetadataCompositePartitionKeyTest
+    - TupleMetadataTest
+    - Udt_Case_Sensitive_Metadata_Test
+    - UdtMetadataTest
+    - Should_Retrieve_Table_Metadata
+    - CreateTable_With_Frozen_Key
+    - CreateTable_With_Frozen_Udt
+    - CreateTable_With_Frozen_Value
+
+    # No 'cql-messages' and 'cql-requests' metrics in Scylla
+    - Should_AllMetricsHaveValidValues_When_AllNodesAreUp
+
+    # Cassandra only; Scylla performs strict validation of the number of bind variables
+    - SimpleStatement_Dictionary_Parameters_CaseInsensitivity_ExcessOfParams
+    - SimpleStatement_Dictionary_Parameters_CaseInsensitivity_NoOverload
+
+    # Cassandra only; Scylla does not support transient replication
+    - TokenAware_TransientReplication_NoHopsAndOnlyFullReplicas
+
+    # UDF: lua doesn't support syntax used in the test
+    - GetFunction_Should_Return_Most_Up_To_Date_Metadata_Via_Events
+
+  flaky:
+    # due to https://github.com/scylladb/csharp-driver/issues/202
+    - TokenMap_Should_RebuildTokenMap_When_NodeIsDecommissioned
+
+    # Scylla 2025.1 rejects LWT on tablets
+    - DeleteIf_Applied_Test
+    - InsertIfNotExists_Applied_Test
+    - UpdateIf_Applied_Test
+    - AddOpenTelemetry_MapperAndMapperAsync_SessionRequestIsParentOfNodeRequest


### PR DESCRIPTION
Fix `run_test.sh` failing when `CSHARP_DRIVER_DIR` is unset in CI
The integration-test-parity change (7016498f35459555c1240052ca9ff431eecee74a) added a hard check that aborted the run if `CSHARP_DRIVER_DIR` did not exist. In CI the driver source is passed to `main.py` as an absolute path argument and reached inside the container via the workspace mount, so `CSHARP_DRIVER_DIR` is never set and its default path does not exist.
The fix removes the fatal check and makes the driver bind-mount conditional: it is mounted to `/datastax-csharp-driver` only when the directory exists locally, and skipped otherwise so CI keeps working via the workspace mount.

You can see the change working on my staging https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/sylwia.szunejko/job/csharp-driver-matrix/46/