### PR TITLE
Mark Datastax 3.22.0 LWT tablet failures flaky

### DIFF
--- a/versions/datastax/3.22.0/ignore.yaml
+++ b/versions/datastax/3.22.0/ignore.yaml
@@ -66,3 +66,9 @@ tests:
 
   flaky:
     - Session_With_Host_Changing_Distance
+
+    # Scylla 2025.1 rejects LWT on tablets
+    - DeleteIf_Applied_Test
+    - InsertIfNotExists_Applied_Test
+    - UpdateIf_Applied_Test
+    - AddOpenTelemetry_MapperAndMapperAsync_SessionRequestIsParentOfNodeRequest


### PR DESCRIPTION
Fixes #25.

## Summary

- Mark the four Datastax C# driver 3.22.0 LWT/tablets failures as expected `flaky` entries.
- Align Datastax 3.22.0 metadata with the existing Scylla driver metadata for the same Scylla 2025.1 tablet limitation.

## Context

Jenkins build #18 for `scylla-2025.1/driver-tests/csharp-driver-matrix-test` fails with four Datastax 3.22.0 tests:

- `DeleteIf_Applied_Test`
- `InsertIfNotExists_Applied_Test`
- `UpdateIf_Applied_Test`
- `AddOpenTelemetry_MapperAndMapperAsync_SessionRequestIsParentOfNodeRequest`

All fail with:

```text
Cannot use LightWeight Transactions for table ...: LWT is not yet supported with tablets
```

These failures are expected for Scylla 2025.1 tablet-backed tables, so the matrix should convert them to `ignored_on_failure` instead of failing the build.

## Testing

- `python3 -m pytest tests/test_ignore_yaml.py tests/test_processjunit.py`