### PR TITLE
Match flaky tests with parameterized names

### DIFF
--- a/processjunit.py
+++ b/processjunit.py
@@ -23,6 +23,19 @@ class ProcessJUnit:
     def summary_report_path(self) -> Path:
         return Path(self.tests_result_xml.parent) / f"{self.tests_result_xml.stem}_summary.xml"
 
+    @staticmethod
+    def is_matching_test_name(testcase_name, test_names) -> bool:
+        """
+        Check whether a JUnit testcase name matches one of the names listed in ignore.yaml.
+
+        Parameterized tests are reported with their arguments appended to the name
+        (e.g. "Should_Create_The_Right_Amount_Of_Connections(True)"), so a plain equality
+        check would never match the bare test name listed in ignore.yaml.
+        """
+        if not testcase_name:
+            return False
+        return any(testcase_name == name or testcase_name.startswith(f"{name}(") for name in test_names)
+
     @lru_cache(maxsize=None)
     def _create_report(self) -> None:
         def get_attribute() -> int:
@@ -33,7 +46,7 @@ class ProcessJUnit:
             failured_tests = testcase_keys[key]
             flaky_tests = self.ignore_set.get('flaky', []) if isinstance(self.ignore_set, dict) else []
             for testcase in testsuite_element.iter("testcase"):
-                if list(testcase.iter("failure")) and testcase.attrib.get("name") in flaky_tests:
+                if list(testcase.iter("failure")) and self.is_matching_test_name(testcase.attrib.get("name"), flaky_tests):
                     failured_tests -= 1
                     testcase_keys["ignored_on_failure"] += 1
             return failured_tests
@@ -111,7 +124,7 @@ class ProcessJUnit:
                 testcase_element = ElementTree.SubElement(testsuit_child, "testcase", attrib=testcase_attrib)
                 testcase_details = list(element)
                 flaky_failure = (
-                    element.attrib.get("name") in flaky_tests
+                    self.is_matching_test_name(element.attrib.get("name"), flaky_tests)
                     and any(detail.tag == "failure" for detail in testcase_details)
                 )
                 if flaky_failure:

--- a/tests/test_processjunit.py
+++ b/tests/test_processjunit.py
@@ -131,3 +131,58 @@ def test_summary_preserves_testsuite_skipped_attribute_without_skipped_elements(
     report = ProcessJUnit(junit_file_xml=junit_file, tag="3.22.0", ignore_set={"ignore": [], "flaky": []})
 
     assert report.summary["testsuite_summary"]["skipped"] == 3
+
+
+def test_flaky_matches_parameterized_testcase_names(tmp_path):
+    junit_file = tmp_path / "scylla_3.22.0.4.xml"
+    junit_file.write_text(
+        """\
+<testsuites>
+  <testsuite name="CSharpTests" tests="2" errors="0" skipped="0" failures="2" time="0.200">
+    <testcase classname="C.Tests" name="Should_Create_The_Right_Amount_Of_Connections(True)" time="0.100">
+      <failure message="boom" type="AssertionError">Expected: 4 But was: 2</failure>
+    </testcase>
+    <testcase classname="C.Tests" name="Should_Create_The_Right_Amount_Of_Connections(False)" time="0.100">
+      <failure message="boom" type="AssertionError">Expected: 3 But was: 2</failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+""",
+        encoding="utf-8",
+    )
+
+    report = ProcessJUnit(
+        junit_file_xml=junit_file,
+        tag="3.22.0.4",
+        ignore_set={"ignore": [], "flaky": ["Should_Create_The_Right_Amount_Of_Connections"]},
+    )
+
+    assert report.summary["testsuite_summary"]["failures"] == 0
+    assert report.summary["testsuite_summary"]["ignored_on_failure"] == 2
+    assert not report.is_failed
+
+    root = ElementTree.parse(junit_file).getroot()
+    suite = root.find("./testsuite")
+    assert suite.attrib["failures"] == "0"
+    assert len(suite.findall("./testcase/ignored_on_failure")) == 2
+
+
+def test_flaky_does_not_match_test_name_prefix(tmp_path):
+    junit_file = tmp_path / "scylla_3.22.0.4.xml"
+    junit_file.write_text(
+        """\
+<testsuites>
+  <testsuite name="CSharpTests" tests="1" errors="0" skipped="0" failures="1" time="0.100">
+    <testcase classname="C.Tests" name="fails_but_not_flaky" time="0.100">
+      <failure message="boom" type="AssertionError">stack line 1</failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+""",
+        encoding="utf-8",
+    )
+
+    report = ProcessJUnit(junit_file_xml=junit_file, tag="3.22.0.4", ignore_set={"ignore": [], "flaky": ["fails"]})
+
+    assert report.summary["testsuite_summary"]["failures"] == 1
+    assert report.is_failed


### PR DESCRIPTION
NUnit reports parameterized test cases with their arguments appended to the name, e.g. "Should_Create_The_Right_Amount_Of_Connections(True)". The flaky list in ignore.yaml holds bare test names, so the exact-equality check never matched and known-flaky parameterized tests were reported as real failures.

Add is_matching_test_name() which matches a testcase when its name equals the ignore.yaml entry or starts with "<entry>(", and use it in both filter_out_ignored_failed_test() and save_after_analysis().